### PR TITLE
Automate the release of documentation for Antora

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,58 @@
+name: Docs
+
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - "*"
+
+jobs:
+  antora:
+    runs-on: ubuntu-latest
+    if: ${{ contains(github.ref, 'tags') }}
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Configure Git
+      run: |
+        git config user.name "Antora via GitHub Actions"
+        git config user.email "actions@github.com"
+    - name: Parse semver string
+      id: semver
+      uses: booxmedialtd/ws-action-parse-semver@v1
+      with:
+        input_string: ${{ github.ref }}
+        version_extractor_regex: '\/v(.*)$'
+    - name: Set variables
+      run: |
+        echo "MINOR_VERSION=${{ steps.semver.outputs.major }}.${{ steps.semver.outputs.minor }}" >> $GITHUB_ENV
+        echo "BRANCH_NAME=docs/v${{ steps.semver.outputs.major }}.${{ steps.semver.outputs.minor }}" >> $GITHUB_ENV
+    - name: Set branch name for Prerelease
+      if: ${{ steps.semver.outputs.prerelease != '' }}
+      # Cover all prereleases in one single rc branch. Administrators should manually delete the docs/vX.Y-rc branches from time to time for cleanup rc releases.
+      run: echo "BRANCH_NAME=docs/v${{ env.MINOR_VERSION}}-rc" >> $GITHUB_ENV
+
+    - name: Checkout remote branch if exists
+      run: git checkout ${{ env.BRANCH_NAME }}
+      continue-on-error: true
+    - name: Rebase if possible
+      run: git rebase ${GITHUB_REF##*/} ${{ env.BRANCH_NAME }}
+      continue-on-error: true
+    - name: Create new branch if not existing
+      run: git switch --create ${{ env.BRANCH_NAME }}
+      continue-on-error: true
+
+    - name: Patch Antora file for Release
+      run: yq eval 'del(.prerelease) | del (.display_version) | .version = "${{ env.MINOR_VERSION }}"' -i docs/antora.yml
+      if: ${{ steps.semver.outputs.prerelease == '' }}
+    - name: Patch Antora file for Prerelease
+      run: yq eval 'del (.display_version) | .version = "${{ env.MINOR_VERSION }}", .prerelease = "-${{ steps.semver.outputs.prerelease }}"' -i docs/antora.yml
+      if: ${{ steps.semver.outputs.prerelease != '' }}
+
+    - name: Commit
+      run: git commit -all --message "Update version for Antora" --author "Antora via GitHub Actions <actions@github.com>"
+      continue-on-error: true
+    - name: Push
+      run: git push --atomic --force --set-upstream origin ${{ env.BRANCH_NAME }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,8 +2,6 @@ name: Docs
 
 on:
   push:
-    branches:
-      - master
     tags:
       - "*"
 
@@ -31,8 +29,7 @@ jobs:
         echo "BRANCH_NAME=docs/v${{ steps.semver.outputs.major }}.${{ steps.semver.outputs.minor }}" >> $GITHUB_ENV
     - name: Set branch name for Prerelease
       if: ${{ steps.semver.outputs.prerelease != '' }}
-      # Cover all prereleases in one single rc branch. Administrators should manually delete the docs/vX.Y-rc branches from time to time for cleanup rc releases.
-      run: echo "BRANCH_NAME=docs/v${{ env.MINOR_VERSION}}-rc" >> $GITHUB_ENV
+      run: echo "BRANCH_NAME=${{ env.BRANCH_NAME }}-rc" >> $GITHUB_ENV
 
     - name: Checkout remote branch if exists
       run: git checkout ${{ env.BRANCH_NAME }}
@@ -52,7 +49,12 @@ jobs:
       if: ${{ steps.semver.outputs.prerelease != '' }}
 
     - name: Commit
-      run: git commit -all --message "Update version for Antora" --author "Antora via GitHub Actions <actions@github.com>"
+      run: git commit -all --message "Update version for Antora"
       continue-on-error: true
     - name: Push
       run: git push --atomic --force --set-upstream origin ${{ env.BRANCH_NAME }}
+
+    - name: Cleanup prerelease branch if existing
+      if: ${{ steps.semver.outputs.prerelease == '' }}
+      run: git push origin --delete ${{ env.BRANCH_NAME }}-rc
+      continue-on-error: true

--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -1,7 +1,5 @@
 * xref:index.adoc[Home]
-ifeval::['{page-origin-reftype}' == 'tag']
-* https://github.com/k8up-io/k8up/releases/tag/{page-origin-refname}[Changelog,window=_blank]
-endif::[]
+* https://github.com/k8up-io/k8up/releases[Changelog,window=_blank]
 
 .Tutorials
 * xref:tutorials/tutorial.adoc[Introduction]


### PR DESCRIPTION
## Summary

This should now build documentation for tags using a "release" branch just for Antora

* Builds documentation with pushes to `master`. Master branch is considered Antora "prerelease"
  * Includes any branches matching "docs/v*" as releases.
  * Includes branches matching "docs/v*-rc* as prereleases.

* Builds documentation with `tag` pushes.
  * Creates a new branch with Major and Minor pattern, e.g. `v1.2.3` will create branch `docs/v1.2`
  * Patch versions will cause the branch to be rebased onto the tag
  * Prereleases will get their own branch per minor version, e.g. `v1.2.3-rc1` will create branch `docs/v1.2-rc`
  * All Prereleases belonging to the same minor version will cause the branch to be rebased onto latest matching rc tag.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`,
      as they show up in the changelog
- [x] Update the documentation.
- [x] Update tests.
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
