### PR TITLE
Fixes link to k8up helm chart in docs

### DIFF
--- a/docs/modules/ROOT/pages/how-tos/upgrade.adoc
+++ b/docs/modules/ROOT/pages/how-tos/upgrade.adoc
@@ -65,7 +65,7 @@ NOTE: You might need to adapt the commands to your needs.
 
 === Prepare new Helm release
 
-The https://github.com/appuio/charts/tree/master/k8up[Helm Chart v1.0] comes with a few new and changed properties.
+The https://github.com/appuio/charts/tree/master/appuio/k8up[Helm Chart v1.0] comes with a few new and changed properties.
 Please consult the README.
 
 Most notably, the Chart is targeted to recent Kubernetes versions.

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -5,7 +5,7 @@ image::k8up-logo.svg[]
 [discrete]
 == Introduction
 
-K8up (pronounced `/keɪtæpp/` or simply "ketchup") is a Kubernetes Operator distributed via a https://github.com/appuio/charts/tree/master/k8up[Helm chart], compatible with https://www.openshift.com/[OpenShift] and plain https://kubernetes.io/[Kubernetes]. It allows cluster operators to:
+K8up (pronounced `/keɪtæpp/` or simply "ketchup") is a Kubernetes Operator distributed via a https://github.com/appuio/charts/tree/master/appuio/k8up[Helm chart], compatible with https://www.openshift.com/[OpenShift] and plain https://kubernetes.io/[Kubernetes]. It allows cluster operators to:
 
 * Backup all PVCs marked as `ReadWriteMany` or with a specific label.
 * Perform individual, on-demand backups.


### PR DESCRIPTION
## Summary

Fixes #524 , which reported that the link to the helm chart is broken.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`,
      as they show up in the changelog
- [x] Update the documentation.
- [ ] Update tests.
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
