### PR TITLE
Only publish arch-agnostic Docker image tags

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -21,6 +21,7 @@ dockers:
   - "quay.io/k8up-io/k8up:v{{ .Version }}-amd64"
   goarch: amd64
   use: buildx
+  skip_push: true # the manifests will be pushed
   build_flag_templates:
   - "--platform=linux/amd64"
   extra_files: &dockers_extra_files
@@ -31,6 +32,7 @@ dockers:
   - "quay.io/k8up-io/k8up:v{{ .Version }}-arm64"
   goarch: arm64
   use: buildx
+  skip_push: true # the manifests will be pushed
   build_flag_templates:
   - "--platform=linux/arm64"
   extra_files: *dockers_extra_files


### PR DESCRIPTION
## Summary

Currently, goreleaser pushes intermediate images such as [`v2.0.0-rc3-arm64`](https://github.com/k8up-io/k8up/pkgs/container/k8up/8063600?tag=v2.0.0-rc3-arm64). Users should actually not need to be interested in the tag specific to the CPU architecture of the Docker image, but only in the agnostic tag, i.e. `v2.0.0-rc3`, and Docker will resolve the correct underlying images.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`,
      as they show up in the changelog
- [ ] Update the documentation.
- [ ] Update tests.
- [ ] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
