### PR TITLE
Fix STATS_URL and PROM_URL not being applied to backup pod

### DIFF
--- a/operator/executor/backup_utils.go
+++ b/operator/executor/backup_utils.go
@@ -118,8 +118,8 @@ func (b *BackupExecutor) setupEnvVars() []corev1.EnvVar {
 		}
 	}
 
-	vars.SetString("STATS_URL", cfg.Config.GlobalStatsURL)
-	vars.SetString("PROM_URL", cfg.Config.PromURL)
+	vars.SetStringOrDefault("STATS_URL", b.backup.Spec.StatsURL, cfg.Config.GlobalStatsURL)
+	vars.SetStringOrDefault("PROM_URL", b.backup.Spec.PromURL, cfg.Config.PromURL)
 	vars.SetString("BACKUPCOMMAND_ANNOTATION", cfg.Config.BackupCommandAnnotation)
 	vars.SetString("FILEEXTENSION_ANNOTATION", cfg.Config.FileExtensionAnnotation)
 

--- a/operator/executor/generic.go
+++ b/operator/executor/generic.go
@@ -51,6 +51,15 @@ func (e *EnvVarConverter) SetString(key, value string) {
 	e.setEntry(key, envVarEntry{stringEnv: &value})
 }
 
+// SetStringOrDefault adds a string key and value pair to the environment.
+// If value is an empty string, it will use the given default value.
+func (e *EnvVarConverter) SetStringOrDefault(key, value, def string) {
+	if value == "" {
+		value = def
+	}
+	e.setEntry(key, envVarEntry{stringEnv: &value})
+}
+
 // SetEnvVarSource add an EnvVarSource to the environment with the given key.
 func (e *EnvVarConverter) SetEnvVarSource(key string, value *corev1.EnvVarSource) {
 	e.setEntry(key, envVarEntry{envVarSource: value})


### PR DESCRIPTION
## Summary

Fix STATS_URL and PROM_URL not being applied to backup pod
The fields in the spec were not even used

Fixes #535 

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`,
      as they show up in the changelog
- [ ] Update the documentation.
- [x] Update tests.
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
