### PR TITLE
Revert "Only push final Docker images"

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -21,7 +21,6 @@ dockers:
   - "quay.io/k8up-io/k8up:v{{ .Version }}-amd64"
   goarch: amd64
   use: buildx
-  skip_push: true # the manifests will be pushed
   build_flag_templates:
   - "--platform=linux/amd64"
   extra_files: &dockers_extra_files
@@ -32,7 +31,6 @@ dockers:
   - "quay.io/k8up-io/k8up:v{{ .Version }}-arm64"
   goarch: arm64
   use: buildx
-  skip_push: true # the manifests will be pushed
   build_flag_templates:
   - "--platform=linux/arm64"
   extra_files: *dockers_extra_files


### PR DESCRIPTION


## Summary

* This reverts #534 
* Turns out that the arch-specific-tags HAVE to be pushed as well, otherwise publishing the manifest fails (see https://github.com/k8up-io/k8up/runs/3837405976?check_suite_focus=true, `docker manifests: failed to publish artifacts: failed to create ghcr.io/k8up-io/k8up:v2.0.0-rc4: exit status 1: manifest unknown`

Setting label `ignore` on both PRs since last v1.x release there wouldn't be any change.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`,
      as they show up in the changelog
- [ ] Update the documentation.
- [ ] Update tests.
- [ ] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
