### PR TITLE
refactor: move from io/ioutil to io and os package

### DIFF
--- a/cmd/restic/integration_test.go
+++ b/cmd/restic/integration_test.go
@@ -10,7 +10,6 @@ import (
 	"context"
 	"encoding/json"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -62,7 +61,7 @@ func newTestErrorChannel() chan error {
 func (w *webhookserver) runWebServer(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/", func(wr http.ResponseWriter, r *http.Request) {
-		w.jsonData, _ = ioutil.ReadAll(r.Body)
+		w.jsonData, _ = io.ReadAll(r.Body)
 	})
 
 	srv := &testServer{
@@ -194,7 +193,7 @@ func createTestFiles(t *testing.T) {
 		err := os.MkdirAll(dir, os.ModePerm)
 		require.NoError(t, err)
 
-		err = ioutil.WriteFile(file, []byte(testfileContent), os.ModePerm)
+		err = os.WriteFile(file, []byte(testfileContent), os.ModePerm)
 		require.NoError(t, err)
 
 		abs, _ := filepath.Abs(file)
@@ -298,7 +297,7 @@ func TestRestoreDisk(t *testing.T) {
 	restoredir := os.Getenv(restoreDirEnvKey)
 	backupdir := os.Getenv(backupDirEnvKey)
 	restoreFilePath := filepath.Join(restoredir, backupdir, "PVC2/test.txt")
-	contents, err := ioutil.ReadFile(restoreFilePath)
+	contents, err := os.ReadFile(restoreFilePath)
 	require.NoError(t, err)
 
 	assert.Equalf(t, testfileContent, string(contents), "restored content of '%s' is not as expected", restoreFilePath)

--- a/restic/cli/backup.go
+++ b/restic/cli/backup.go
@@ -3,7 +3,6 @@ package cli
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"time"
@@ -28,7 +27,7 @@ func (r *Restic) Backup(backupDir string, tags ArrayOpts) error {
 		return nil
 	}
 
-	files, err := ioutil.ReadDir(backupDir)
+	files, err := os.ReadDir(backupDir)
 	if err != nil {
 		return fmt.Errorf("can't read backupdir '%s': %w", backupDir, err)
 	}

--- a/restic/cli/stats.go
+++ b/restic/cli/stats.go
@@ -2,7 +2,7 @@ package cli
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"os"
 
 	"github.com/prometheus/client_golang/prometheus"
 
@@ -217,7 +217,7 @@ func (p *PromMetrics) ToProm() []prometheus.Collector {
 }
 
 func (r *Restic) getMountedFolders() []string {
-	files, err := ioutil.ReadDir(cfg.Config.BackupDir)
+	files, err := os.ReadDir(cfg.Config.BackupDir)
 	if err != nil {
 		r.logger.WithName("MountCollector").Error(err, "can't list mounted folders for stats")
 		return []string{}


### PR DESCRIPTION
## Summary

The `io/ioutil` package has been deprecated in Go 1.16 (See https://golang.org/doc/go1.16#ioutil). Since k8up has been upgraded to Go 1.17 (#492), this PR replaces the existing `io/ioutil` functions with their new definitions in `io` and `os` packages.

## Checklist
- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`,
      as they show up in the changelog
