### PR TITLE
Rename prometheus metrics namespace from 'baas' to 'k8up'

### DIFF
--- a/config/samples/prometheus/rules.yaml
+++ b/config/samples/prometheus/rules.yaml
@@ -1,8 +1,8 @@
 groups:
 - name: K8up
   rules:
-  - alert: baas_last_errors
-    expr: baas_backup_restic_last_errors > 0
+  - alert: K8upBackupLastErrors
+    expr: k8up_backup_restic_last_errors > 0
     for: 1m
     labels:
       severity: critical

--- a/docs/modules/ROOT/pages/explanations/what-has-changed-in-v2.adoc
+++ b/docs/modules/ROOT/pages/explanations/what-has-changed-in-v2.adoc
@@ -25,3 +25,4 @@ We have big plans for future versions of K8up, but they all require a solid foun
 We believe that K8up v2 is that solid foundation.
 
 Going forward, K8up v2 drops support for very old Kubernetes versions, for example OpenShift 3.11.
+If you are using Prometheus for alerting, note that metrics names changed their prefix from `baas` to `k8up`.

--- a/docs/modules/ROOT/pages/how-tos/restore.adoc
+++ b/docs/modules/ROOT/pages/how-tos/restore.adoc
@@ -125,7 +125,7 @@ You’ll need the credentials from the secrets and the encryption key. With that
 
 [source,bash]
 ----
-export RESTIC_REPOSITORY=s3:http://localhost/baas
+export RESTIC_REPOSITORY=s3:http://localhost/k8up
 export RESTIC_PASSWORD=p@assword
 export AWS_ACCESS_KEY_ID=8U0UDNYPNUDTUS1LIAF3
 export AWS_SECRET_ACCESS_KEY=ip3cdrkXcHmH4S7if7erKPNoxDn27V0vrg6CHHem

--- a/restic/cli/stats.go
+++ b/restic/cli/stats.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	prometheusNamespace = "baas"
+	prometheusNamespace = "k8up"
 	prometheusSubsystem = "backup_restic"
 )
 


### PR DESCRIPTION
## Summary

* Renames metrics namespace from `baas` to `k8up`. It was meant to be included in the v2.0.0 release but was overseen.

NOTE: This is a breaking change for all K8up alert rules, as metrics like `baas_backup_restic_last_errors` will become `k8up_backup_restic_last_errors`. Adapt your alert rules if necessary.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`,
      as they show up in the changelog
- [x] Update the documentation.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
