### PR TITLE
Add note that restore to PVC doesn't work if backup from stdin

### DIFF
--- a/docs/modules/ROOT/pages/how-tos/restore.adoc
+++ b/docs/modules/ROOT/pages/how-tos/restore.adoc
@@ -42,6 +42,12 @@ This will trigger a one time job to restore the latest snapshot to S3.
 
 == Restore from S3 to PVC
 
+[NOTE]
+====
+You can't restore from backups that were done from `stdin` (`PreBackupPod` or backup command annotation).
+In those cases, use the manual restore option described below using the `restic dump` or `restic mount` commands.
+====
+
 First, create a new PVC to extract the data to:
 
 [source,yaml]


### PR DESCRIPTION

## Summary

This note indicates that a restore method isn't available for stdin-based backups.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`,
      as they show up in the changelog
- [x] Update the documentation.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
