### PR TITLE
Add kind-minio target to makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -159,11 +159,18 @@ kind-clean: ## Removes the kind instance if it exists.
 
 .PHONY: kind-run
 kind-run: export KUBECONFIG = $(KIND_KUBECONFIG)
-kind-run: kind-setup install run-operator ## Runs the operator on the local host but configured for the kind cluster
+kind-run: kind-setup kind-minio install run-operator ## Runs the operator on the local host but configured for the kind cluster
 
 kind-e2e-image: docker-build
 	$(e2e_make) kind-e2e-image
 
+.PHONY: kind-minio
+kind-minio: $(minio_sentinel)
+
+$(minio_sentinel): export KUBECONFIG = $(KIND_KUBECONFIG)
+$(minio_sentinel): kind-setup
+	kubectl apply -f $(SAMPLES_ROOT_DIR)/deployments/minio.yaml
+	@touch $@
 ###
 ### E2E Test
 ###

--- a/Makefile.vars.mk
+++ b/Makefile.vars.mk
@@ -16,6 +16,9 @@ CRD_FILE ?= k8up-crd.yaml
 CRD_ROOT_DIR ?= config/crd/apiextensions.k8s.io
 CRD_DOCS_REF_PATH ?= docs/modules/ROOT/pages/references/api-reference.adoc
 
+SAMPLES_ROOT_DIR ?= config/samples
+minio_sentinel = $(e2etest_dir)/minio_sentinel
+
 KIND_NODE_VERSION ?= v1.23.1
 KIND ?= go run sigs.k8s.io/kind
 KIND_KUBECONFIG ?= $(e2etest_dir)/kind-kubeconfig-$(KIND_NODE_VERSION)

--- a/config/samples/deployments/minio.yaml
+++ b/config/samples/deployments/minio.yaml
@@ -1,0 +1,86 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: minio
+
+---
+
+apiVersion: apps/v1 #  for k8s versions before 1.9.0 use apps/v1beta2  and before 1.8.0 use extensions/v1beta1
+kind: Deployment
+metadata:
+  # This name uniquely identifies the Deployment
+  name: minio
+  namespace: minio
+spec:
+  selector:
+    matchLabels:
+      app: minio
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: minio
+    spec:
+      containers:
+      - name: minio
+        image: docker.io/minio/minio:latest
+        resources: {}
+        args:
+        - server
+        - /storage
+        - --console-address
+        - ":9001"
+        env:
+        - name: MINIO_ROOT_PASSWORD
+          value: minioadmin
+        - name: MINIO_ROOT_USER
+          value: "minioadmin"
+        ports:
+        - containerPort: 9000
+          hostPort: 9000
+        - containerPort: 9001
+          hostPort: 9001
+        volumeMounts:
+        - name: storage
+          mountPath: "/storage"
+      volumes:
+      - name: storage
+        persistentVolumeClaim:
+          claimName: minio
+
+---
+
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: minio
+  namespace: minio
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: minio
+  name: minio
+  namespace: minio
+spec:
+  ports:
+    - name: "9000"
+      port: 9000
+      targetPort: 9000
+    - name: gui
+      port: 9001
+      targetPort: 9001
+  selector:
+    app: minio
+status:
+  loadBalancer: {}

--- a/config/samples/k8up_v1_archive.yaml
+++ b/config/samples/k8up_v1_archive.yaml
@@ -8,7 +8,7 @@ spec:
     key: password
   restoreMethod:
     s3:
-      endpoint: http://10.144.1.224:9000
+      endpoint: http://minio.minio:9000
       bucket: restoremini
       accessKeyIDSecretRef:
         name: backup-credentials
@@ -18,7 +18,7 @@ spec:
         key: password
   backend:
     s3:
-      endpoint: http://10.144.1.224:9000
+      endpoint: http://minio.minio:9000
       bucket: k8up
       accessKeyIDSecretRef:
         name: backup-credentials

--- a/config/samples/k8up_v1_backup.yaml
+++ b/config/samples/k8up_v1_backup.yaml
@@ -14,7 +14,7 @@ spec:
       name: backup-repo
       key: password
     s3:
-      endpoint: http://10.144.13.4:9000
+      endpoint: http://minio.minio:9000
       bucket: k8up
       accessKeyIDSecretRef:
         name: backup-credentials
@@ -22,4 +22,3 @@ spec:
       secretAccessKeySecretRef:
         name: backup-credentials
         key: password
-  promURL: http://10.144.13.4:9000

--- a/config/samples/k8up_v1_check.yaml
+++ b/config/samples/k8up_v1_check.yaml
@@ -12,7 +12,7 @@ spec:
       name: backup-repo
       key: password
     s3:
-      endpoint: http://10.144.1.224:9000
+      endpoint: http://minio.minio:9000
       bucket: k8up
       accessKeyIDSecretRef:
         name: backup-credentials
@@ -20,4 +20,3 @@ spec:
       secretAccessKeySecretRef:
         name: backup-credentials
         key: password
-  promURL: http://10.144.1.224:9000

--- a/config/samples/k8up_v1_prune.yaml
+++ b/config/samples/k8up_v1_prune.yaml
@@ -11,7 +11,7 @@ spec:
       name: backup-repo
       key: password
     s3:
-      endpoint: http://10.144.1.224:9000
+      endpoint: http://minio.minio:9000
       bucket: k8up
       accessKeyIDSecretRef:
         name: backup-credentials

--- a/config/samples/k8up_v1_restore.yaml
+++ b/config/samples/k8up_v1_restore.yaml
@@ -12,7 +12,7 @@ spec:
       name: backup-repo
       key: password
     s3:
-      endpoint: http://10.144.1.224:9000
+      endpoint: http://minio.minio:9000
       bucket: k8up
       accessKeyIDSecretRef:
         name: backup-credentials
@@ -28,7 +28,7 @@ metadata:
 spec:
   restoreMethod:
     s3:
-      endpoint: http://10.144.1.224:9000
+      endpoint: http://minio.minio:9000
       bucket: restoremini
       accessKeyIDSecretRef:
         name: backup-credentials
@@ -41,7 +41,7 @@ spec:
       name: backup-repo
       key: password
     s3:
-      endpoint: http://10.144.1.224:9000
+      endpoint: http://minio.minio:9000
       bucket: k8up
       accessKeyIDSecretRef:
         name: backup-credentials

--- a/config/samples/k8up_v1_schedule.yaml
+++ b/config/samples/k8up_v1_schedule.yaml
@@ -16,7 +16,7 @@ spec:
       name: backup-repo
       key: password
     s3:
-      endpoint: http://10.144.1.224:9000
+      endpoint: http://minio.minio:9000
       bucket: k8up
       accessKeyIDSecretRef:
         name: backup-credentials
@@ -28,7 +28,7 @@ spec:
     schedule: '0 * * * *'
     restoreMethod:
       s3:
-        endpoint: http://10.144.1.224:9000
+        endpoint: http://minio.minio:9000
         bucket: restoremini
         accessKeyIDSecretRef:
           name: backup-credentials
@@ -40,7 +40,7 @@ spec:
     schedule: '* * * * *'
     failedJobsHistoryLimit: 2
     successfulJobsHistoryLimit: 2
-    promURL: http://10.144.1.224:9000
+    promURL: http://minio.minio:9000
     resources:
       requests:
         memory: "64Mi"
@@ -54,7 +54,7 @@ spec:
         memory: "64Mi"
         cpu: "250m"
     schedule: '@hourly-random'
-    promURL: http://10.144.1.224:9000
+    promURL: http://minio.minio:9000
   prune:
     schedule: '*/2 * * * *'
     retention:


### PR DESCRIPTION
## Summary
This target will deploy a minio instance into the kind cluster. Prior to
this the minio instance had to be running seperately.


## Checklist

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`,
      as they show up in the changelog



