### PR TITLE
Add 'envFrom' generic configuration for backend spec

### DIFF
--- a/api/v1/backend.go
+++ b/api/v1/backend.go
@@ -15,13 +15,15 @@ type (
 	Backend struct {
 		// RepoPasswordSecretRef references a secret key to look up the restic repository password
 		RepoPasswordSecretRef *corev1.SecretKeySelector `json:"repoPasswordSecretRef,omitempty"`
-		Local                 *LocalSpec                `json:"local,omitempty"`
-		S3                    *S3Spec                   `json:"s3,omitempty"`
-		GCS                   *GCSSpec                  `json:"gcs,omitempty"`
-		Azure                 *AzureSpec                `json:"azure,omitempty"`
-		Swift                 *SwiftSpec                `json:"swift,omitempty"`
-		B2                    *B2Spec                   `json:"b2,omitempty"`
-		Rest                  *RestServerSpec           `json:"rest,omitempty"`
+		// EnvFrom adds all environment variables from a an external source to the Restic job.
+		EnvFrom []corev1.EnvFromSource `json:"envFrom,omitempty"`
+		Local   *LocalSpec             `json:"local,omitempty"`
+		S3      *S3Spec                `json:"s3,omitempty"`
+		GCS     *GCSSpec               `json:"gcs,omitempty"`
+		Azure   *AzureSpec             `json:"azure,omitempty"`
+		Swift   *SwiftSpec             `json:"swift,omitempty"`
+		B2      *B2Spec                `json:"b2,omitempty"`
+		Rest    *RestServerSpec        `json:"rest,omitempty"`
 	}
 
 	// +k8s:deepcopy-gen=false

--- a/api/v1/backend_test.go
+++ b/api/v1/backend_test.go
@@ -201,3 +201,35 @@ func TestBackend_IsBackendEqualTo(t *testing.T) {
 		})
 	}
 }
+
+func Test_AppendEnvFromToContainer(t *testing.T) {
+	t.Run("GivenFromEnv_WhenAppendedToContainer_ThenContainerHasFromEnv", func(t *testing.T) {
+		// Given a container with an empty EnvFrom
+		var container = &corev1.Container{
+			EnvFrom: []corev1.EnvFromSource{},
+		}
+
+		// And a Backend config with an EnvFrom, containing a secret reference called
+		secretRef := new(corev1.SecretEnvSource)
+		secretRef.Name = "my-secret"
+
+		var spec = &RunnableSpec{
+			Backend: &Backend{
+				EnvFrom: []corev1.EnvFromSource{{
+					Prefix:       "test-prefix",
+					ConfigMapRef: new(corev1.ConfigMapEnvSource),
+					SecretRef:    secretRef,
+				}},
+			},
+			Resources:          corev1.ResourceRequirements{},
+			PodSecurityContext: nil,
+		}
+
+		// When I Append EnvFrom to the container
+		spec.AppendEnvFromToContainer(container)
+
+		// Then My container has the secret reference in the EnvFrom structure
+		assert.Equal(t, "test-prefix", container.EnvFrom[0].Prefix)
+		assert.Equal(t, "my-secret", container.EnvFrom[0].SecretRef.Name)
+	})
+}

--- a/api/v1/runnable_types.go
+++ b/api/v1/runnable_types.go
@@ -15,3 +15,10 @@ type RunnableSpec struct {
 	// PodSecurityContext describes the security context with which this action shall be executed.
 	PodSecurityContext *corev1.PodSecurityContext `json:"podSecurityContext,omitempty"`
 }
+
+// AppendEnvFromToContainer will add EnvFromSource from the given RunnableSpec to the Container
+func (in *RunnableSpec) AppendEnvFromToContainer(containerSpec *corev1.Container) {
+	if in.Backend != nil {
+		containerSpec.EnvFrom = append(containerSpec.EnvFrom, in.Backend.EnvFrom...)
+	}
+}

--- a/api/v1/zz_generated.deepcopy.go
+++ b/api/v1/zz_generated.deepcopy.go
@@ -172,6 +172,13 @@ func (in *Backend) DeepCopyInto(out *Backend) {
 		*out = new(corev1.SecretKeySelector)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.EnvFrom != nil {
+		in, out := &in.EnvFrom, &out.EnvFrom
+		*out = make([]corev1.EnvFromSource, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	if in.Local != nil {
 		in, out := &in.Local, &out.Local
 		*out = new(LocalSpec)

--- a/config/crd/apiextensions.k8s.io/v1/base/k8up.io_archives.yaml
+++ b/config/crd/apiextensions.k8s.io/v1/base/k8up.io_archives.yaml
@@ -135,6 +135,41 @@ spec:
                       path:
                         type: string
                     type: object
+                  envFrom:
+                    description: EnvFrom adds all environment variables from a an
+                      external source to the Restic job.
+                    items:
+                      description: EnvFromSource represents the source of a set of
+                        ConfigMaps
+                      properties:
+                        configMapRef:
+                          description: The ConfigMap to select from
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                            optional:
+                              description: Specify whether the ConfigMap must be defined
+                              type: boolean
+                          type: object
+                        prefix:
+                          description: An optional identifier to prepend to each key
+                            in the ConfigMap. Must be a C_IDENTIFIER.
+                          type: string
+                        secretRef:
+                          description: The Secret to select from
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                            optional:
+                              description: Specify whether the Secret must be defined
+                              type: boolean
+                          type: object
+                      type: object
+                    type: array
                   gcs:
                     properties:
                       accessTokenSecretRef:

--- a/config/crd/apiextensions.k8s.io/v1/base/k8up.io_backups.yaml
+++ b/config/crd/apiextensions.k8s.io/v1/base/k8up.io_backups.yaml
@@ -142,6 +142,41 @@ spec:
                       path:
                         type: string
                     type: object
+                  envFrom:
+                    description: EnvFrom adds all environment variables from a an
+                      external source to the Restic job.
+                    items:
+                      description: EnvFromSource represents the source of a set of
+                        ConfigMaps
+                      properties:
+                        configMapRef:
+                          description: The ConfigMap to select from
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                            optional:
+                              description: Specify whether the ConfigMap must be defined
+                              type: boolean
+                          type: object
+                        prefix:
+                          description: An optional identifier to prepend to each key
+                            in the ConfigMap. Must be a C_IDENTIFIER.
+                          type: string
+                        secretRef:
+                          description: The Secret to select from
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                            optional:
+                              description: Specify whether the Secret must be defined
+                              type: boolean
+                          type: object
+                      type: object
+                    type: array
                   gcs:
                     properties:
                       accessTokenSecretRef:

--- a/config/crd/apiextensions.k8s.io/v1/base/k8up.io_checks.yaml
+++ b/config/crd/apiextensions.k8s.io/v1/base/k8up.io_checks.yaml
@@ -136,6 +136,41 @@ spec:
                       path:
                         type: string
                     type: object
+                  envFrom:
+                    description: EnvFrom adds all environment variables from a an
+                      external source to the Restic job.
+                    items:
+                      description: EnvFromSource represents the source of a set of
+                        ConfigMaps
+                      properties:
+                        configMapRef:
+                          description: The ConfigMap to select from
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                            optional:
+                              description: Specify whether the ConfigMap must be defined
+                              type: boolean
+                          type: object
+                        prefix:
+                          description: An optional identifier to prepend to each key
+                            in the ConfigMap. Must be a C_IDENTIFIER.
+                          type: string
+                        secretRef:
+                          description: The Secret to select from
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                            optional:
+                              description: Specify whether the Secret must be defined
+                              type: boolean
+                          type: object
+                      type: object
+                    type: array
                   gcs:
                     properties:
                       accessTokenSecretRef:

--- a/config/crd/apiextensions.k8s.io/v1/base/k8up.io_prunes.yaml
+++ b/config/crd/apiextensions.k8s.io/v1/base/k8up.io_prunes.yaml
@@ -136,6 +136,41 @@ spec:
                       path:
                         type: string
                     type: object
+                  envFrom:
+                    description: EnvFrom adds all environment variables from a an
+                      external source to the Restic job.
+                    items:
+                      description: EnvFromSource represents the source of a set of
+                        ConfigMaps
+                      properties:
+                        configMapRef:
+                          description: The ConfigMap to select from
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                            optional:
+                              description: Specify whether the ConfigMap must be defined
+                              type: boolean
+                          type: object
+                        prefix:
+                          description: An optional identifier to prepend to each key
+                            in the ConfigMap. Must be a C_IDENTIFIER.
+                          type: string
+                        secretRef:
+                          description: The Secret to select from
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                            optional:
+                              description: Specify whether the Secret must be defined
+                              type: boolean
+                          type: object
+                      type: object
+                    type: array
                   gcs:
                     properties:
                       accessTokenSecretRef:

--- a/config/crd/apiextensions.k8s.io/v1/base/k8up.io_restores.yaml
+++ b/config/crd/apiextensions.k8s.io/v1/base/k8up.io_restores.yaml
@@ -136,6 +136,41 @@ spec:
                       path:
                         type: string
                     type: object
+                  envFrom:
+                    description: EnvFrom adds all environment variables from a an
+                      external source to the Restic job.
+                    items:
+                      description: EnvFromSource represents the source of a set of
+                        ConfigMaps
+                      properties:
+                        configMapRef:
+                          description: The ConfigMap to select from
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                            optional:
+                              description: Specify whether the ConfigMap must be defined
+                              type: boolean
+                          type: object
+                        prefix:
+                          description: An optional identifier to prepend to each key
+                            in the ConfigMap. Must be a C_IDENTIFIER.
+                          type: string
+                        secretRef:
+                          description: The Secret to select from
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                            optional:
+                              description: Specify whether the Secret must be defined
+                              type: boolean
+                          type: object
+                      type: object
+                    type: array
                   gcs:
                     properties:
                       accessTokenSecretRef:

--- a/config/crd/apiextensions.k8s.io/v1/base/k8up.io_schedules.yaml
+++ b/config/crd/apiextensions.k8s.io/v1/base/k8up.io_schedules.yaml
@@ -130,6 +130,45 @@ spec:
                           path:
                             type: string
                         type: object
+                      envFrom:
+                        description: EnvFrom adds all environment variables from a
+                          an external source to the Restic job.
+                        items:
+                          description: EnvFromSource represents the source of a set
+                            of ConfigMaps
+                          properties:
+                            configMapRef:
+                              description: The ConfigMap to select from
+                              properties:
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap must
+                                    be defined
+                                  type: boolean
+                              type: object
+                            prefix:
+                              description: An optional identifier to prepend to each
+                                key in the ConfigMap. Must be a C_IDENTIFIER.
+                              type: string
+                            secretRef:
+                              description: The Secret to select from
+                              properties:
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret must be
+                                    defined
+                                  type: boolean
+                              type: object
+                          type: object
+                        type: array
                       gcs:
                         properties:
                           accessTokenSecretRef:
@@ -674,6 +713,41 @@ spec:
                       path:
                         type: string
                     type: object
+                  envFrom:
+                    description: EnvFrom adds all environment variables from a an
+                      external source to the Restic job.
+                    items:
+                      description: EnvFromSource represents the source of a set of
+                        ConfigMaps
+                      properties:
+                        configMapRef:
+                          description: The ConfigMap to select from
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                            optional:
+                              description: Specify whether the ConfigMap must be defined
+                              type: boolean
+                          type: object
+                        prefix:
+                          description: An optional identifier to prepend to each key
+                            in the ConfigMap. Must be a C_IDENTIFIER.
+                          type: string
+                        secretRef:
+                          description: The Secret to select from
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                            optional:
+                              description: Specify whether the Secret must be defined
+                              type: boolean
+                          type: object
+                      type: object
+                    type: array
                   gcs:
                     properties:
                       accessTokenSecretRef:
@@ -926,6 +1000,45 @@ spec:
                           path:
                             type: string
                         type: object
+                      envFrom:
+                        description: EnvFrom adds all environment variables from a
+                          an external source to the Restic job.
+                        items:
+                          description: EnvFromSource represents the source of a set
+                            of ConfigMaps
+                          properties:
+                            configMapRef:
+                              description: The ConfigMap to select from
+                              properties:
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap must
+                                    be defined
+                                  type: boolean
+                              type: object
+                            prefix:
+                              description: An optional identifier to prepend to each
+                                key in the ConfigMap. Must be a C_IDENTIFIER.
+                              type: string
+                            secretRef:
+                              description: The Secret to select from
+                              properties:
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret must be
+                                    defined
+                                  type: boolean
+                              type: object
+                          type: object
+                        type: array
                       gcs:
                         properties:
                           accessTokenSecretRef:
@@ -1418,6 +1531,45 @@ spec:
                           path:
                             type: string
                         type: object
+                      envFrom:
+                        description: EnvFrom adds all environment variables from a
+                          an external source to the Restic job.
+                        items:
+                          description: EnvFromSource represents the source of a set
+                            of ConfigMaps
+                          properties:
+                            configMapRef:
+                              description: The ConfigMap to select from
+                              properties:
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap must
+                                    be defined
+                                  type: boolean
+                              type: object
+                            prefix:
+                              description: An optional identifier to prepend to each
+                                key in the ConfigMap. Must be a C_IDENTIFIER.
+                              type: string
+                            secretRef:
+                              description: The Secret to select from
+                              properties:
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret must be
+                                    defined
+                                  type: boolean
+                              type: object
+                          type: object
+                        type: array
                       gcs:
                         properties:
                           accessTokenSecretRef:
@@ -2072,6 +2224,45 @@ spec:
                           path:
                             type: string
                         type: object
+                      envFrom:
+                        description: EnvFrom adds all environment variables from a
+                          an external source to the Restic job.
+                        items:
+                          description: EnvFromSource represents the source of a set
+                            of ConfigMaps
+                          properties:
+                            configMapRef:
+                              description: The ConfigMap to select from
+                              properties:
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap must
+                                    be defined
+                                  type: boolean
+                              type: object
+                            prefix:
+                              description: An optional identifier to prepend to each
+                                key in the ConfigMap. Must be a C_IDENTIFIER.
+                              type: string
+                            secretRef:
+                              description: The Secret to select from
+                              properties:
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret must be
+                                    defined
+                                  type: boolean
+                              type: object
+                          type: object
+                        type: array
                       gcs:
                         properties:
                           accessTokenSecretRef:
@@ -2610,6 +2801,45 @@ spec:
                           path:
                             type: string
                         type: object
+                      envFrom:
+                        description: EnvFrom adds all environment variables from a
+                          an external source to the Restic job.
+                        items:
+                          description: EnvFromSource represents the source of a set
+                            of ConfigMaps
+                          properties:
+                            configMapRef:
+                              description: The ConfigMap to select from
+                              properties:
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap must
+                                    be defined
+                                  type: boolean
+                              type: object
+                            prefix:
+                              description: An optional identifier to prepend to each
+                                key in the ConfigMap. Must be a C_IDENTIFIER.
+                              type: string
+                            secretRef:
+                              description: The Secret to select from
+                              properties:
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret must be
+                                    defined
+                                  type: boolean
+                              type: object
+                          type: object
+                        type: array
                       gcs:
                         properties:
                           accessTokenSecretRef:

--- a/docs/modules/ROOT/examples/open-stack-swift-auth.yaml
+++ b/docs/modules/ROOT/examples/open-stack-swift-auth.yaml
@@ -1,0 +1,45 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "open-stack-secret"
+stringData:
+  OS_AUTH_URL: "https://your-provider.auth.com/v3"
+  OS_IDENTITY_API_VERSION: "3"
+  OS_USER_DOMAIN_NAME: "Default"
+  OS_PROJECT_DOMAIN_NAME: "Default"
+  OS_TENANT_ID: "Open Stack Tenant Id"
+  OS_TENANT_NAME: "Open Stack Tenant Name"
+  OS_USERNAME: "Username"
+  OS_PASSWORD: "Password"
+  OS_REGION_NAME: "US"
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "restic-repository-password"
+stringData:
+  password: "secret_pass"
+
+---
+apiVersion: k8up.io/v1
+kind: Backup
+metadata:
+  name: k8up-test-swift
+spec:
+  tags:
+    - prod
+    - archive
+    - important
+  failedJobsHistoryLimit: 4
+  successfulJobsHistoryLimit: 0
+  backend:
+    envFrom:
+    - secretRef:
+        name: "open-stack-secret"
+    repoPasswordSecretRef:
+      name: "restic-repository-password"
+      key: "password"
+    swift:
+      path: "/container-path"
+      container: "my-backup-container"

--- a/docs/modules/ROOT/examples/tutorial/backup.yaml
+++ b/docs/modules/ROOT/examples/tutorial/backup.yaml
@@ -7,6 +7,9 @@ spec:
   successfulJobsHistoryLimit: 2
   promURL: http://minio:9000
   backend:
+    envFrom: # Adding any arbitrary env variables to the job container spec
+    - secretRef:
+        name: "secret-name"
     repoPasswordSecretRef:
       name: backup-repo
       key: password

--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -9,6 +9,7 @@
 * xref:how-tos/installation.adoc[Installation]
 * xref:how-tos/upgrade.adoc[Upgrade K8up]
 * xref:how-tos/backup.adoc[Backup]
+* xref:how-tos/generic-env-vars.adoc[Generic Environment Variables]
 * xref:how-tos/application-aware-backups.adoc[Application-Aware Backups]
 * xref:how-tos/prebackuppod.adoc[Pre-Backup Pods]
 * xref:how-tos/schedules.adoc[Schedules]

--- a/docs/modules/ROOT/pages/how-tos/generic-env-vars.adoc
+++ b/docs/modules/ROOT/pages/how-tos/generic-env-vars.adoc
@@ -1,0 +1,25 @@
+= Generic Restic Environment Variables
+
+Most of the supported backup backends allow you to specify authentication details as secret values.
+
+One such example is the S3 backend spec; it has `accessKeyIDSecretRef` and `secretAccessKeySecretRef` fields.
+
+It is however sometimes useful to pass additional environment variables to the container that runs the backup.
+This can be achieved with the help of the `envFrom` field that references a config map or a secret at the backend level.
+
+Please be aware that you could potentially add conflicting or duplicate environment variables.
+
+Check the api reference for the xref:references/api-reference.adoc#{anchor_prefix}-github-com-k8up-io-k8up-api-v1-backend[Backend].
+
+You can read link:https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/#configure-all-key-value-pairs-in-a-configmap-as-container-environment-variables[the kubernetes documentation] for more information on how to use `envFrom`.
+
+== Open Stack Swift Authentication Example
+
+The following example shows you how to configure Open Stack Swift authentication using a Kubernetes secret and `envFrom` configuration for your backend.
+
+You can read more on link:https://wiki.openstack.org/wiki/OpenStackClient/Authentication[Open Stack Client Authentication].
+
+[source,yaml]
+----
+include::example$open-stack-swift-auth.yaml[]
+----

--- a/docs/modules/ROOT/pages/references/api-reference.adoc
+++ b/docs/modules/ROOT/pages/references/api-reference.adoc
@@ -153,6 +153,7 @@ Backend allows configuring several backend implementations. It is expected that 
 |===
 | Field | Description
 | *`repoPasswordSecretRef`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#secretkeyselector-v1-core[$$SecretKeySelector$$]__ | RepoPasswordSecretRef references a secret key to look up the restic repository password
+| *`envFrom`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#envfromsource-v1-core[$$EnvFromSource$$] array__ | EnvFrom adds all environment variables from a an external source to the Restic job.
 | *`local`* __xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-localspec[$$LocalSpec$$]__ | 
 | *`s3`* __xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-s3spec[$$S3Spec$$]__ | 
 | *`gcs`* __xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-gcsspec[$$GCSSpec$$]__ | 

--- a/operator/executor/archive.go
+++ b/operator/executor/archive.go
@@ -61,6 +61,7 @@ func (a *ArchiveExecutor) startArchive(archiveJob *batchv1.Job, archive *k8upv1.
 	a.RegisterJobSucceededConditionCallback()
 
 	archiveJob.Spec.Template.Spec.Containers[0].Env = a.setupEnvVars(archive)
+	archive.Spec.AppendEnvFromToContainer(&archiveJob.Spec.Template.Spec.Containers[0])
 	archiveJob.Spec.Template.Spec.Containers[0].Args = a.setupArgs(archive)
 
 	err := a.Client.Create(a.CTX, archiveJob)

--- a/operator/executor/backup.go
+++ b/operator/executor/backup.go
@@ -123,6 +123,7 @@ func (b *BackupExecutor) startBackup(backupJob *batchv1.Job) error {
 	}
 
 	backupJob.Spec.Template.Spec.Containers[0].Env = b.setupEnvVars()
+	b.backup.Spec.AppendEnvFromToContainer(&backupJob.Spec.Template.Spec.Containers[0])
 	backupJob.Spec.Template.Spec.Volumes = volumes
 	backupJob.Spec.Template.Spec.ServiceAccountName = cfg.Config.ServiceAccount
 	backupJob.Spec.Template.Spec.Containers[0].VolumeMounts = b.newVolumeMounts(volumes)

--- a/operator/executor/check.go
+++ b/operator/executor/check.go
@@ -63,6 +63,7 @@ func (c *CheckExecutor) startCheck(checkJob *batchv1.Job) error {
 	c.registerCheckCallback()
 
 	checkJob.Spec.Template.Spec.Containers[0].Env = c.setupEnvVars()
+	c.check.Spec.AppendEnvFromToContainer(&checkJob.Spec.Template.Spec.Containers[0])
 	checkJob.Spec.Template.Spec.Containers[0].Args = []string{"-check"}
 
 	err := c.CreateObjectIfNotExisting(checkJob)

--- a/operator/executor/prune.go
+++ b/operator/executor/prune.go
@@ -66,6 +66,7 @@ func (p *PruneExecutor) startPrune(pruneJob *batchv1.Job, prune *k8upv1.Prune) {
 	p.RegisterJobSucceededConditionCallback()
 
 	pruneJob.Spec.Template.Spec.Containers[0].Env = p.setupEnvVars(prune)
+	prune.Spec.AppendEnvFromToContainer(&pruneJob.Spec.Template.Spec.Containers[0])
 	pruneJob.Spec.Template.Spec.Containers[0].Args = append([]string{"-prune"}, BuildTagArgs(prune.Spec.Retention.Tags)...)
 
 	if err := p.Client.Create(p.CTX, pruneJob); err != nil {

--- a/operator/executor/restore.go
+++ b/operator/executor/restore.go
@@ -93,6 +93,7 @@ func (r *RestoreExecutor) buildRestoreObject(restore *k8upv1.Restore) (*batchv1.
 	j.GetLabels()[job.K8upExclusive] = strconv.FormatBool(r.Exclusive())
 
 	j.Spec.Template.Spec.Containers[0].Env = r.setupEnvVars(restore)
+	restore.Spec.AppendEnvFromToContainer(&j.Spec.Template.Spec.Containers[0])
 
 	volumes, volumeMounts := r.volumeConfig(restore)
 	j.Spec.Template.Spec.Volumes = volumes


### PR DESCRIPTION
## Summary

Added envFrom configuration for backends
EnvFrom can be used to add arbitrary env variables 'in bulk' to the job container template.
This feature can be useful in implementing some generic authentication

Signed-off-by: Alexander KIRILOV <aleksandar.kirilov@proxym.fr>

## Checklist
- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`,
      as they show up in the changelog
- [x] Update the documentation.
- [x] Update tests.
- [x] Link this PR to related issues.
