### PR TITLE
Ensure https is shown in code block in tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ It’s that easy. K8up takes care of the rest. It also provides a Prometheus end
 The documentation is written in AsciiDoc and published with Antora to [k8up.io](https://k8up.io/).
 It's source is available in the `docs/` directory.
 
+Run `make docs-preview` to build the docs and preview changes.
+
 ## Contributing
 
 K8up is written using [Kubebuilder](https://github.com/kubernetes-sigs/kubebuilder).

--- a/docs/modules/ROOT/pages/tutorials/tutorial.adoc
+++ b/docs/modules/ROOT/pages/tutorials/tutorial.adoc
@@ -66,7 +66,7 @@ IMPORTANT: On some laptops, running Minikube on battery power severely undermine
 * `kubectl apply -k wordpress`
 
 . Install the CRDs K8up uses:
-* `kubectl apply -f https://github.com/k8up-io/k8up/releases/download/{k8up_version}/k8up-crd.yaml`
+* `kubectl apply -f \https://github.com/k8up-io/k8up/releases/download/{k8up_version}/k8up-crd.yaml`
 
 . Install K8up in Minikube:
 * `helm repo add appuio \https://charts.appuio.ch`


### PR DESCRIPTION
## Summary
Having an URL in a code block without `\https` will be rendered as a link in a browser  and not showing `https://`; thias leads to errors when copy pasting to the CLI while running the tutorial.


## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`,
      as they show up in the changelog
- [x] Update the documentation.
