### PR TITLE
Add additional port for webUI in tutorial

### DIFF
--- a/docs/modules/ROOT/examples/tutorial/backup.yaml
+++ b/docs/modules/ROOT/examples/tutorial/backup.yaml
@@ -7,9 +7,6 @@ spec:
   successfulJobsHistoryLimit: 2
   promURL: http://minio:9000
   backend:
-    envFrom: # Adding any arbitrary env variables to the job container spec
-    - secretRef:
-        name: "secret-name"
     repoPasswordSecretRef:
       name: backup-repo
       key: password

--- a/docs/modules/ROOT/examples/tutorial/minio/deployment.yaml
+++ b/docs/modules/ROOT/examples/tutorial/minio/deployment.yaml
@@ -41,6 +41,7 @@ spec:
               key: password
         ports:
         - containerPort: 9000
+        - containerPort: 9001
         readinessProbe:
           httpGet:
             path: /minio/health/ready

--- a/docs/modules/ROOT/examples/tutorial/minio/deployment.yaml
+++ b/docs/modules/ROOT/examples/tutorial/minio/deployment.yaml
@@ -26,8 +26,7 @@ spec:
         args:
         - server
         - /data
-        - '--console-address'
-        - ':9001'
+        - '--console-address=:9001'
         env:
         - name: MINIO_ROOT_USER
           valueFrom:

--- a/docs/modules/ROOT/examples/tutorial/minio/deployment.yaml
+++ b/docs/modules/ROOT/examples/tutorial/minio/deployment.yaml
@@ -26,6 +26,8 @@ spec:
         args:
         - server
         - /data
+        - '--console-address'
+        - ':9001'
         env:
         - name: MINIO_ROOT_USER
           valueFrom:

--- a/docs/modules/ROOT/examples/tutorial/minio/service.yaml
+++ b/docs/modules/ROOT/examples/tutorial/minio/service.yaml
@@ -7,11 +7,11 @@ spec:
   type: NodePort
   ports:
     - port: 9000
-      name: minio-api-port
+      name: api
       targetPort: 9000
       protocol: TCP
     - port: 9001
-      name: mini-browser-port
+      name: webui
       targetPort: 9001
       protocol: TCP
   selector:

--- a/docs/modules/ROOT/examples/tutorial/minio/service.yaml
+++ b/docs/modules/ROOT/examples/tutorial/minio/service.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: Service
 metadata:
@@ -6,7 +7,12 @@ spec:
   type: NodePort
   ports:
     - port: 9000
+      name: minio-api-port
       targetPort: 9000
+      protocol: TCP
+    - port: 9001
+      name: mini-browser-port
+      targetPort: 9001
       protocol: TCP
   selector:
     app: minio

--- a/docs/modules/ROOT/examples/tutorial/scripts/6_stop.sh
+++ b/docs/modules/ROOT/examples/tutorial/scripts/6_stop.sh
@@ -1,3 +1,6 @@
 #!/usr/bin/env bash
 
+kill $MINIO_PORT
+echo $MINIO_PORT
+minikube stop
 minikube delete

--- a/docs/modules/ROOT/examples/tutorial/scripts/environment.sh
+++ b/docs/modules/ROOT/examples/tutorial/scripts/environment.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 export KUBECONFIG=""
-export RESTIC_REPOSITORY=s3:$(minikube service minio --url)/backups/
+export RESTIC_REPOSITORY=s3:$(minikube service list | grep 9001 | cut -d"|" -f 5 | tr -d "[:space:]")/backups/
 export RESTIC_PASSWORD=p@ssw0rd
 export AWS_ACCESS_KEY_ID=minio
 export AWS_SECRET_ACCESS_KEY=minio123

--- a/docs/modules/ROOT/examples/tutorial/scripts/environment.sh
+++ b/docs/modules/ROOT/examples/tutorial/scripts/environment.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 
+kubectl port-forward svc/minio 9000:9000 &
+export MINIO_PORT=$!
 export KUBECONFIG=""
-export RESTIC_REPOSITORY=s3:$(minikube service list | grep 9001 | cut -d"|" -f 5 | tr -d "[:space:]")/backups/
+export RESTIC_REPOSITORY=s3:http://localhost:9000/backups/
 export RESTIC_PASSWORD=p@ssw0rd
 export AWS_ACCESS_KEY_ID=minio
 export AWS_SECRET_ACCESS_KEY=minio123

--- a/docs/modules/ROOT/pages/tutorials/tutorial.adoc
+++ b/docs/modules/ROOT/pages/tutorials/tutorial.adoc
@@ -227,7 +227,7 @@ To restore using Restic, set these variables (in a Unix-based system; for Window
 [source,bash]
 ....
 export KUBECONFIG=""
-export RESTIC_REPOSITORY=s3:$(minikube service minio --url)/backups/
+export RESTIC_REPOSITORY=s3:$(minikube service list | grep 9000 | cut -d"|" -f 5 | tr -d "[:space:]")/backups/
 export RESTIC_PASSWORD=p@ssw0rd
 export AWS_ACCESS_KEY_ID=minio
 export AWS_SECRET_ACCESS_KEY=minio123

--- a/docs/modules/ROOT/pages/tutorials/tutorial.adoc
+++ b/docs/modules/ROOT/pages/tutorials/tutorial.adoc
@@ -227,6 +227,7 @@ To restore using Restic, set these variables (in a Unix-based system; for Window
 [source,bash]
 ....
 kubectl port-forward svc/minio 9000:9000 &
+export MINIO_PORT=$!
 export KUBECONFIG=""
 export RESTIC_REPOSITORY=s3:http://localhost:9000/backups/
 export RESTIC_PASSWORD=p@ssw0rd
@@ -336,7 +337,7 @@ Whenever K8up performs a backup, it creates a pod for the job. The one we create
 [[step_6]]
 === Scheduling regular backups
 
-NOTE: The operations of this step can be executed at once using the `scripts/7_schedule.sh` script.
+NOTE: The operations of this step can be executed at once using the `scripts/5_schedule.sh` script.
 
 Instead of performing backups manually, you can also set a schedule on which backups are performed automatically. This requires specifying the schedule in `cron` format.
 
@@ -381,7 +382,9 @@ TIP: Running the `watch restic snapshots` command will rerun restic every 2 seco
 [[step_7]]
 === Cleaning up the cluster
 
-NOTE: The operations of this step can be executed at once using the `scripts/8_stop.sh` script.
+NOTE: The operations of this step can be executed at once using the `scripts/6_stop.sh` script.
+
+Stop port forwarding with `kill $MINIO_PORT`.
 
 When you are done with this tutorial, just execute the `minikube stop` command to shut the cluster down. If you would like to get rid of it completely, run `minikube delete`.
 

--- a/docs/modules/ROOT/pages/tutorials/tutorial.adoc
+++ b/docs/modules/ROOT/pages/tutorials/tutorial.adoc
@@ -226,8 +226,9 @@ To restore using Restic, set these variables (in a Unix-based system; for Window
 
 [source,bash]
 ....
+kubectl port-forward svc/minio 9000:9000 &
 export KUBECONFIG=""
-export RESTIC_REPOSITORY=s3:$(minikube service list | grep 9000 | cut -d"|" -f 5 | tr -d "[:space:]")/backups/
+export RESTIC_REPOSITORY=s3:http://localhost:9000/backups/
 export RESTIC_PASSWORD=p@ssw0rd
 export AWS_ACCESS_KEY_ID=minio
 export AWS_SECRET_ACCESS_KEY=minio123


### PR DESCRIPTION
## Summary

New Minio version has a different port for the browser GUI than for the
API. This commit adds support for that so the tutorial user can open it
in a browser as documented.

Signed-off-by: Daniel Hauswirth <info@chloesoe.ch>



## Checklist

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`,
      as they show up in the changelog
- [x] Update the documentation.
- [x] Link this PR to related issues.

relates to https://github.com/k8up-io/k8up/pull/664
