### PR TITLE
Append /v2 in Go module path

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Determine Go version from go.mod
-      run: echo "GO_VERSION=$(grep "go 1." go.mod | cut -d " " -f 2)" >> $GITHUB_ENV
+      run: echo "GO_VERSION=$(go mod edit -json | jq -r .Go)" >> $GITHUB_ENV
     - uses: actions/setup-go@v3
       with:
         go-version: ${{ env.GO_VERSION }}
@@ -32,4 +32,4 @@ jobs:
         CC_TEST_REPORTER_ID: 8b249859554fe1e4e283329f31f8cdace9ecfed692ce3cf733fd9ce22ed40594
       with:
         coverageLocations: cover.out:gocov
-        prefix: github.com/${{ github.repository }}
+        prefix: github.com/${{ github.repository }}/v2

--- a/api/v1/backend.go
+++ b/api/v1/backend.go
@@ -6,7 +6,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 
-	"github.com/k8up-io/k8up/operator/cfg"
+	"github.com/k8up-io/k8up/v2/operator/cfg"
 )
 
 type (

--- a/api/v1/backend_test.go
+++ b/api/v1/backend_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 
-	"github.com/k8up-io/k8up/operator/cfg"
+	"github.com/k8up-io/k8up/v2/operator/cfg"
 )
 
 var tests = map[string]struct {

--- a/api/v1/history_limits_test.go
+++ b/api/v1/history_limits_test.go
@@ -3,7 +3,7 @@ package v1_test
 import (
 	"testing"
 
-	k8upv1 "github.com/k8up-io/k8up/api/v1"
+	k8upv1 "github.com/k8up-io/k8up/v2/api/v1"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/api/v1/job_name_test.go
+++ b/api/v1/job_name_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	k8upv1 "github.com/k8up-io/k8up/api/v1"
+	k8upv1 "github.com/k8up-io/k8up/v2/api/v1"
 )
 
 func TestJobName(t *testing.T) {

--- a/api/v1/object_list_test.go
+++ b/api/v1/object_list_test.go
@@ -3,7 +3,7 @@ package v1_test
 import (
 	"testing"
 
-	k8upv1 "github.com/k8up-io/k8up/api/v1"
+	k8upv1 "github.com/k8up-io/k8up/v2/api/v1"
 
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/cmd/k8up/main.go
+++ b/cmd/k8up/main.go
@@ -12,9 +12,9 @@ import (
 	"go.uber.org/zap/zapcore"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	"github.com/k8up-io/k8up/cmd"
-	"github.com/k8up-io/k8up/cmd/operator"
-	"github.com/k8up-io/k8up/cmd/restic"
+	"github.com/k8up-io/k8up/v2/cmd"
+	"github.com/k8up-io/k8up/v2/cmd/operator"
+	"github.com/k8up-io/k8up/v2/cmd/restic"
 )
 
 // Strings are populated by Goreleaser

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -14,11 +14,11 @@ import (
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
 
-	k8upv1 "github.com/k8up-io/k8up/api/v1"
-	"github.com/k8up-io/k8up/cmd"
-	"github.com/k8up-io/k8up/controllers"
-	"github.com/k8up-io/k8up/operator/cfg"
-	"github.com/k8up-io/k8up/operator/executor"
+	k8upv1 "github.com/k8up-io/k8up/v2/api/v1"
+	"github.com/k8up-io/k8up/v2/cmd"
+	"github.com/k8up-io/k8up/v2/controllers"
+	"github.com/k8up-io/k8up/v2/operator/cfg"
+	"github.com/k8up-io/k8up/v2/operator/executor"
 	// +kubebuilder:scaffold:imports
 )
 

--- a/cmd/restic/integration_test.go
+++ b/cmd/restic/integration_test.go
@@ -22,10 +22,10 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zaptest"
 
-	"github.com/k8up-io/k8up/restic/cfg"
-	"github.com/k8up-io/k8up/restic/cli"
-	"github.com/k8up-io/k8up/restic/s3"
-	"github.com/k8up-io/k8up/restic/stats"
+	"github.com/k8up-io/k8up/v2/restic/cfg"
+	"github.com/k8up-io/k8up/v2/restic/cli"
+	"github.com/k8up-io/k8up/v2/restic/s3"
+	"github.com/k8up-io/k8up/v2/restic/stats"
 )
 
 type webhookserver struct {

--- a/cmd/restic/main.go
+++ b/cmd/restic/main.go
@@ -11,11 +11,11 @@ import (
 	"github.com/urfave/cli/v2"
 	"k8s.io/client-go/tools/clientcmd"
 
-	"github.com/k8up-io/k8up/cmd"
-	"github.com/k8up-io/k8up/restic/cfg"
-	resticCli "github.com/k8up-io/k8up/restic/cli"
-	"github.com/k8up-io/k8up/restic/kubernetes"
-	"github.com/k8up-io/k8up/restic/stats"
+	"github.com/k8up-io/k8up/v2/cmd"
+	"github.com/k8up-io/k8up/v2/restic/cfg"
+	resticCli "github.com/k8up-io/k8up/v2/restic/cli"
+	"github.com/k8up-io/k8up/v2/restic/kubernetes"
+	"github.com/k8up-io/k8up/v2/restic/stats"
 )
 
 const (

--- a/common/targzipwriter_test.go
+++ b/common/targzipwriter_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/k8up-io/k8up/common"
+	"github.com/k8up-io/k8up/v2/common"
 )
 
 type MockWriter struct {

--- a/controllers/archive_controller.go
+++ b/controllers/archive_controller.go
@@ -11,10 +11,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
-	k8upv1 "github.com/k8up-io/k8up/api/v1"
-	"github.com/k8up-io/k8up/operator/cfg"
-	"github.com/k8up-io/k8up/operator/handler"
-	"github.com/k8up-io/k8up/operator/job"
+	k8upv1 "github.com/k8up-io/k8up/v2/api/v1"
+	"github.com/k8up-io/k8up/v2/operator/cfg"
+	"github.com/k8up-io/k8up/v2/operator/handler"
+	"github.com/k8up-io/k8up/v2/operator/job"
 )
 
 // ArchiveReconciler reconciles a Archive object

--- a/controllers/backup_controller.go
+++ b/controllers/backup_controller.go
@@ -11,10 +11,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
-	k8upv1 "github.com/k8up-io/k8up/api/v1"
-	"github.com/k8up-io/k8up/operator/cfg"
-	"github.com/k8up-io/k8up/operator/handler"
-	"github.com/k8up-io/k8up/operator/job"
+	k8upv1 "github.com/k8up-io/k8up/v2/api/v1"
+	"github.com/k8up-io/k8up/v2/operator/cfg"
+	"github.com/k8up-io/k8up/v2/operator/handler"
+	"github.com/k8up-io/k8up/v2/operator/job"
 )
 
 // BackupReconciler reconciles a Backup object

--- a/controllers/backup_integration_test.go
+++ b/controllers/backup_integration_test.go
@@ -11,10 +11,10 @@ import (
 	"github.com/stretchr/testify/suite"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	k8upv1 "github.com/k8up-io/k8up/api/v1"
-	"github.com/k8up-io/k8up/controllers"
-	"github.com/k8up-io/k8up/envtest"
-	"github.com/k8up-io/k8up/operator/observer"
+	k8upv1 "github.com/k8up-io/k8up/v2/api/v1"
+	"github.com/k8up-io/k8up/v2/controllers"
+	"github.com/k8up-io/k8up/v2/envtest"
+	"github.com/k8up-io/k8up/v2/operator/observer"
 )
 
 type BackupTestSuite struct {

--- a/controllers/backup_it_utils_test.go
+++ b/controllers/backup_it_utils_test.go
@@ -20,8 +20,8 @@ import (
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	k8upv1 "github.com/k8up-io/k8up/api/v1"
-	k8upObserver "github.com/k8up-io/k8up/operator/observer"
+	k8upv1 "github.com/k8up-io/k8up/v2/api/v1"
+	k8upObserver "github.com/k8up-io/k8up/v2/operator/observer"
 )
 
 const (

--- a/controllers/check_controller.go
+++ b/controllers/check_controller.go
@@ -11,10 +11,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
-	k8upv1 "github.com/k8up-io/k8up/api/v1"
-	"github.com/k8up-io/k8up/operator/cfg"
-	"github.com/k8up-io/k8up/operator/handler"
-	"github.com/k8up-io/k8up/operator/job"
+	k8upv1 "github.com/k8up-io/k8up/v2/api/v1"
+	"github.com/k8up-io/k8up/v2/operator/cfg"
+	"github.com/k8up-io/k8up/v2/operator/handler"
+	"github.com/k8up-io/k8up/v2/operator/job"
 )
 
 // CheckReconciler reconciles a Check object

--- a/controllers/check_integration_test.go
+++ b/controllers/check_integration_test.go
@@ -17,10 +17,10 @@ import (
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	k8upv1 "github.com/k8up-io/k8up/api/v1"
-	"github.com/k8up-io/k8up/controllers"
-	"github.com/k8up-io/k8up/envtest"
-	"github.com/k8up-io/k8up/operator/observer"
+	k8upv1 "github.com/k8up-io/k8up/v2/api/v1"
+	"github.com/k8up-io/k8up/v2/controllers"
+	"github.com/k8up-io/k8up/v2/envtest"
+	"github.com/k8up-io/k8up/v2/operator/observer"
 )
 
 type CheckTestSuite struct {

--- a/controllers/job_controller.go
+++ b/controllers/job_controller.go
@@ -11,8 +11,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	"github.com/k8up-io/k8up/operator/handler"
-	"github.com/k8up-io/k8up/operator/job"
+	"github.com/k8up-io/k8up/v2/operator/handler"
+	"github.com/k8up-io/k8up/v2/operator/job"
 )
 
 // JobReconciler reconciles a Job object

--- a/controllers/prune_controller.go
+++ b/controllers/prune_controller.go
@@ -11,10 +11,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
-	k8upv1 "github.com/k8up-io/k8up/api/v1"
-	"github.com/k8up-io/k8up/operator/cfg"
-	"github.com/k8up-io/k8up/operator/handler"
-	"github.com/k8up-io/k8up/operator/job"
+	k8upv1 "github.com/k8up-io/k8up/v2/api/v1"
+	"github.com/k8up-io/k8up/v2/operator/cfg"
+	"github.com/k8up-io/k8up/v2/operator/handler"
+	"github.com/k8up-io/k8up/v2/operator/job"
 )
 
 // PruneReconciler reconciles a Prune object

--- a/controllers/restore_controller.go
+++ b/controllers/restore_controller.go
@@ -11,10 +11,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
-	k8upv1 "github.com/k8up-io/k8up/api/v1"
-	"github.com/k8up-io/k8up/operator/cfg"
-	"github.com/k8up-io/k8up/operator/handler"
-	"github.com/k8up-io/k8up/operator/job"
+	k8upv1 "github.com/k8up-io/k8up/v2/api/v1"
+	"github.com/k8up-io/k8up/v2/operator/cfg"
+	"github.com/k8up-io/k8up/v2/operator/handler"
+	"github.com/k8up-io/k8up/v2/operator/job"
 )
 
 // RestoreReconciler reconciles a Restore object

--- a/controllers/restore_integration_test.go
+++ b/controllers/restore_integration_test.go
@@ -15,9 +15,9 @@ import (
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	k8upv1 "github.com/k8up-io/k8up/api/v1"
-	"github.com/k8up-io/k8up/controllers"
-	"github.com/k8up-io/k8up/envtest"
+	k8upv1 "github.com/k8up-io/k8up/v2/api/v1"
+	"github.com/k8up-io/k8up/v2/controllers"
+	"github.com/k8up-io/k8up/v2/envtest"
 )
 
 type RestoreTestSuite struct {

--- a/controllers/schedule_controller.go
+++ b/controllers/schedule_controller.go
@@ -12,10 +12,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	k8upv1 "github.com/k8up-io/k8up/api/v1"
-	"github.com/k8up-io/k8up/operator/cfg"
-	"github.com/k8up-io/k8up/operator/handler"
-	"github.com/k8up-io/k8up/operator/job"
+	k8upv1 "github.com/k8up-io/k8up/v2/api/v1"
+	"github.com/k8up-io/k8up/v2/operator/cfg"
+	"github.com/k8up-io/k8up/v2/operator/handler"
+	"github.com/k8up-io/k8up/v2/operator/job"
 )
 
 // ScheduleReconciler reconciles a Schedule object

--- a/controllers/schedule_controller_test.go
+++ b/controllers/schedule_controller_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	k8upv1 "github.com/k8up-io/k8up/api/v1"
+	k8upv1 "github.com/k8up-io/k8up/v2/api/v1"
 )
 
 func Test_filterEffectiveSchedulesForReferencesOfSchedule(t *testing.T) {

--- a/controllers/schedule_it_test.go
+++ b/controllers/schedule_it_test.go
@@ -10,12 +10,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	k8upv1 "github.com/k8up-io/k8up/api/v1"
-	"github.com/k8up-io/k8up/controllers"
-	"github.com/k8up-io/k8up/envtest"
-	"github.com/k8up-io/k8up/operator/cfg"
-	"github.com/k8up-io/k8up/operator/handler"
-	"github.com/k8up-io/k8up/operator/scheduler"
+	k8upv1 "github.com/k8up-io/k8up/v2/api/v1"
+	"github.com/k8up-io/k8up/v2/controllers"
+	"github.com/k8up-io/k8up/v2/envtest"
+	"github.com/k8up-io/k8up/v2/operator/cfg"
+	"github.com/k8up-io/k8up/v2/operator/handler"
+	"github.com/k8up-io/k8up/v2/operator/scheduler"
 )
 
 type (

--- a/controllers/schedule_it_utils_test.go
+++ b/controllers/schedule_it_utils_test.go
@@ -7,8 +7,8 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	k8upv1 "github.com/k8up-io/k8up/api/v1"
-	"github.com/k8up-io/k8up/operator/handler"
+	k8upv1 "github.com/k8up-io/k8up/v2/api/v1"
+	"github.com/k8up-io/k8up/v2/operator/handler"
 )
 
 func (ts *ScheduleControllerTestSuite) givenScheduleResource(schedule k8upv1.ScheduleDefinition) {

--- a/docs/modules/ROOT/pages/references/api-reference.adoc
+++ b/docs/modules/ROOT/pages/references/api-reference.adoc
@@ -17,35 +17,35 @@ TIP: A more sophisticated documentation is available under https://doc.crds.dev/
 
 
 .Resource Types
-- xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-archive[$$Archive$$]
-- xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-archivelist[$$ArchiveList$$]
-- xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-backup[$$Backup$$]
-- xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-backuplist[$$BackupList$$]
-- xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-check[$$Check$$]
-- xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-checklist[$$CheckList$$]
-- xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-effectiveschedule[$$EffectiveSchedule$$]
-- xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-effectiveschedulelist[$$EffectiveScheduleList$$]
-- xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-prebackuppod[$$PreBackupPod$$]
-- xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-prebackuppodlist[$$PreBackupPodList$$]
-- xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-prune[$$Prune$$]
-- xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-prunelist[$$PruneList$$]
-- xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-restore[$$Restore$$]
-- xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-restorelist[$$RestoreList$$]
-- xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-schedule[$$Schedule$$]
-- xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-schedulelist[$$ScheduleList$$]
-- xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-snapshot[$$Snapshot$$]
-- xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-snapshotlist[$$SnapshotList$$]
+- xref:{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-archive[$$Archive$$]
+- xref:{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-archivelist[$$ArchiveList$$]
+- xref:{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-backup[$$Backup$$]
+- xref:{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-backuplist[$$BackupList$$]
+- xref:{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-check[$$Check$$]
+- xref:{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-checklist[$$CheckList$$]
+- xref:{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-effectiveschedule[$$EffectiveSchedule$$]
+- xref:{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-effectiveschedulelist[$$EffectiveScheduleList$$]
+- xref:{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-prebackuppod[$$PreBackupPod$$]
+- xref:{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-prebackuppodlist[$$PreBackupPodList$$]
+- xref:{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-prune[$$Prune$$]
+- xref:{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-prunelist[$$PruneList$$]
+- xref:{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-restore[$$Restore$$]
+- xref:{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-restorelist[$$RestoreList$$]
+- xref:{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-schedule[$$Schedule$$]
+- xref:{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-schedulelist[$$ScheduleList$$]
+- xref:{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-snapshot[$$Snapshot$$]
+- xref:{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-snapshotlist[$$SnapshotList$$]
 
 
 
-[id="{anchor_prefix}-github-com-k8up-io-k8up-api-v1-archive"]
+[id="{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-archive"]
 === Archive 
 
 Archive is the Schema for the archives API
 
 .Appears In:
 ****
-- xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-archivelist[$$ArchiveList$$]
+- xref:{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-archivelist[$$ArchiveList$$]
 ****
 
 [cols="25a,75a", options="header"]
@@ -55,11 +55,11 @@ Archive is the Schema for the archives API
 | *`kind`* __string__ | `Archive`
 | *`metadata`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#objectmeta-v1-meta[$$ObjectMeta$$]__ | Refer to Kubernetes API documentation for fields of `metadata`.
 
-| *`spec`* __xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-archivespec[$$ArchiveSpec$$]__ | 
+| *`spec`* __xref:{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-archivespec[$$ArchiveSpec$$]__ | 
 |===
 
 
-[id="{anchor_prefix}-github-com-k8up-io-k8up-api-v1-archivelist"]
+[id="{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-archivelist"]
 === ArchiveList 
 
 ArchiveList contains a list of Archive
@@ -73,80 +73,80 @@ ArchiveList contains a list of Archive
 | *`kind`* __string__ | `ArchiveList`
 | *`metadata`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#listmeta-v1-meta[$$ListMeta$$]__ | Refer to Kubernetes API documentation for fields of `metadata`.
 
-| *`items`* __xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-archive[$$Archive$$] array__ | 
+| *`items`* __xref:{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-archive[$$Archive$$] array__ | 
 |===
 
 
-[id="{anchor_prefix}-github-com-k8up-io-k8up-api-v1-archiveschedule"]
+[id="{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-archiveschedule"]
 === ArchiveSchedule 
 
 ArchiveSchedule manages schedules for the archival service
 
 .Appears In:
 ****
-- xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-schedulespec[$$ScheduleSpec$$]
+- xref:{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-schedulespec[$$ScheduleSpec$$]
 ****
 
 [cols="25a,75a", options="header"]
 |===
 | Field | Description
-| *`ArchiveSpec`* __xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-archivespec[$$ArchiveSpec$$]__ | 
-| *`ScheduleCommon`* __xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-schedulecommon[$$ScheduleCommon$$]__ | 
+| *`ArchiveSpec`* __xref:{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-archivespec[$$ArchiveSpec$$]__ | 
+| *`ScheduleCommon`* __xref:{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-schedulecommon[$$ScheduleCommon$$]__ | 
 |===
 
 
-[id="{anchor_prefix}-github-com-k8up-io-k8up-api-v1-archivespec"]
+[id="{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-archivespec"]
 === ArchiveSpec 
 
 ArchiveSpec defines the desired state of Archive.
 
 .Appears In:
 ****
-- xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-archive[$$Archive$$]
-- xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-archiveschedule[$$ArchiveSchedule$$]
+- xref:{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-archive[$$Archive$$]
+- xref:{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-archiveschedule[$$ArchiveSchedule$$]
 ****
 
 [cols="25a,75a", options="header"]
 |===
 | Field | Description
-| *`RestoreSpec`* __xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-restorespec[$$RestoreSpec$$]__ | 
+| *`RestoreSpec`* __xref:{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-restorespec[$$RestoreSpec$$]__ | 
 |===
 
 
-[id="{anchor_prefix}-github-com-k8up-io-k8up-api-v1-azurespec"]
+[id="{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-azurespec"]
 === AzureSpec 
 
 
 
 .Appears In:
 ****
-- xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-backend[$$Backend$$]
+- xref:{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-backend[$$Backend$$]
 ****
 
 
 
-[id="{anchor_prefix}-github-com-k8up-io-k8up-api-v1-b2spec"]
+[id="{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-b2spec"]
 === B2Spec 
 
 
 
 .Appears In:
 ****
-- xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-backend[$$Backend$$]
+- xref:{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-backend[$$Backend$$]
 ****
 
 
 
-[id="{anchor_prefix}-github-com-k8up-io-k8up-api-v1-backend"]
+[id="{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-backend"]
 === Backend 
 
 Backend allows configuring several backend implementations. It is expected that users only configure one storage type.
 
 .Appears In:
 ****
-- xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-backuptemplate[$$BackupTemplate$$]
-- xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-runnablespec[$$RunnableSpec$$]
-- xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-schedulespec[$$ScheduleSpec$$]
+- xref:{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-backuptemplate[$$BackupTemplate$$]
+- xref:{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-runnablespec[$$RunnableSpec$$]
+- xref:{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-schedulespec[$$ScheduleSpec$$]
 ****
 
 [cols="25a,75a", options="header"]
@@ -154,26 +154,26 @@ Backend allows configuring several backend implementations. It is expected that 
 | Field | Description
 | *`repoPasswordSecretRef`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#secretkeyselector-v1-core[$$SecretKeySelector$$]__ | RepoPasswordSecretRef references a secret key to look up the restic repository password
 | *`envFrom`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#envfromsource-v1-core[$$EnvFromSource$$] array__ | EnvFrom adds all environment variables from a an external source to the Restic job.
-| *`local`* __xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-localspec[$$LocalSpec$$]__ | 
-| *`s3`* __xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-s3spec[$$S3Spec$$]__ | 
-| *`gcs`* __xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-gcsspec[$$GCSSpec$$]__ | 
-| *`azure`* __xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-azurespec[$$AzureSpec$$]__ | 
-| *`swift`* __xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-swiftspec[$$SwiftSpec$$]__ | 
-| *`b2`* __xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-b2spec[$$B2Spec$$]__ | 
-| *`rest`* __xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-restserverspec[$$RestServerSpec$$]__ | 
+| *`local`* __xref:{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-localspec[$$LocalSpec$$]__ | 
+| *`s3`* __xref:{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-s3spec[$$S3Spec$$]__ | 
+| *`gcs`* __xref:{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-gcsspec[$$GCSSpec$$]__ | 
+| *`azure`* __xref:{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-azurespec[$$AzureSpec$$]__ | 
+| *`swift`* __xref:{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-swiftspec[$$SwiftSpec$$]__ | 
+| *`b2`* __xref:{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-b2spec[$$B2Spec$$]__ | 
+| *`rest`* __xref:{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-restserverspec[$$RestServerSpec$$]__ | 
 |===
 
 
 
 
-[id="{anchor_prefix}-github-com-k8up-io-k8up-api-v1-backup"]
+[id="{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-backup"]
 === Backup 
 
 Backup is the Schema for the backups API
 
 .Appears In:
 ****
-- xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-backuplist[$$BackupList$$]
+- xref:{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-backuplist[$$BackupList$$]
 ****
 
 [cols="25a,75a", options="header"]
@@ -183,11 +183,11 @@ Backup is the Schema for the backups API
 | *`kind`* __string__ | `Backup`
 | *`metadata`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#objectmeta-v1-meta[$$ObjectMeta$$]__ | Refer to Kubernetes API documentation for fields of `metadata`.
 
-| *`spec`* __xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-backupspec[$$BackupSpec$$]__ | 
+| *`spec`* __xref:{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-backupspec[$$BackupSpec$$]__ | 
 |===
 
 
-[id="{anchor_prefix}-github-com-k8up-io-k8up-api-v1-backuplist"]
+[id="{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-backuplist"]
 === BackupList 
 
 BackupList contains a list of Backup
@@ -201,43 +201,43 @@ BackupList contains a list of Backup
 | *`kind`* __string__ | `BackupList`
 | *`metadata`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#listmeta-v1-meta[$$ListMeta$$]__ | Refer to Kubernetes API documentation for fields of `metadata`.
 
-| *`items`* __xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-backup[$$Backup$$] array__ | 
+| *`items`* __xref:{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-backup[$$Backup$$] array__ | 
 |===
 
 
-[id="{anchor_prefix}-github-com-k8up-io-k8up-api-v1-backupschedule"]
+[id="{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-backupschedule"]
 === BackupSchedule 
 
 BackupSchedule manages schedules for the backup service
 
 .Appears In:
 ****
-- xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-schedulespec[$$ScheduleSpec$$]
+- xref:{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-schedulespec[$$ScheduleSpec$$]
 ****
 
 [cols="25a,75a", options="header"]
 |===
 | Field | Description
-| *`BackupSpec`* __xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-backupspec[$$BackupSpec$$]__ | 
-| *`ScheduleCommon`* __xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-schedulecommon[$$ScheduleCommon$$]__ | 
+| *`BackupSpec`* __xref:{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-backupspec[$$BackupSpec$$]__ | 
+| *`ScheduleCommon`* __xref:{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-schedulecommon[$$ScheduleCommon$$]__ | 
 |===
 
 
-[id="{anchor_prefix}-github-com-k8up-io-k8up-api-v1-backupspec"]
+[id="{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-backupspec"]
 === BackupSpec 
 
 BackupSpec defines a single backup. It must contain all information to connect to the backup repository when applied. If used with defaults or schedules the operator will ensure that the defaults are applied before creating the object on the API.
 
 .Appears In:
 ****
-- xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-backup[$$Backup$$]
-- xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-backupschedule[$$BackupSchedule$$]
+- xref:{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-backup[$$Backup$$]
+- xref:{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-backupschedule[$$BackupSchedule$$]
 ****
 
 [cols="25a,75a", options="header"]
 |===
 | Field | Description
-| *`RunnableSpec`* __xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-runnablespec[$$RunnableSpec$$]__ | 
+| *`RunnableSpec`* __xref:{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-runnablespec[$$RunnableSpec$$]__ | 
 | *`keepJobs`* __integer__ | KeepJobs amount of jobs to keep for later analysis. 
  Deprecated: Use FailedJobsHistoryLimit and SuccessfulJobsHistoryLimit respectively.
 | *`failedJobsHistoryLimit`* __integer__ | FailedJobsHistoryLimit amount of failed jobs to keep for later analysis. KeepJobs is used property is not specified.
@@ -250,14 +250,14 @@ BackupSpec defines a single backup. It must contain all information to connect t
 
 
 
-[id="{anchor_prefix}-github-com-k8up-io-k8up-api-v1-check"]
+[id="{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-check"]
 === Check 
 
 Check is the Schema for the checks API
 
 .Appears In:
 ****
-- xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-checklist[$$CheckList$$]
+- xref:{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-checklist[$$CheckList$$]
 ****
 
 [cols="25a,75a", options="header"]
@@ -267,11 +267,11 @@ Check is the Schema for the checks API
 | *`kind`* __string__ | `Check`
 | *`metadata`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#objectmeta-v1-meta[$$ObjectMeta$$]__ | Refer to Kubernetes API documentation for fields of `metadata`.
 
-| *`spec`* __xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-checkspec[$$CheckSpec$$]__ | 
+| *`spec`* __xref:{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-checkspec[$$CheckSpec$$]__ | 
 |===
 
 
-[id="{anchor_prefix}-github-com-k8up-io-k8up-api-v1-checklist"]
+[id="{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-checklist"]
 === CheckList 
 
 CheckList contains a list of Check
@@ -285,43 +285,43 @@ CheckList contains a list of Check
 | *`kind`* __string__ | `CheckList`
 | *`metadata`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#listmeta-v1-meta[$$ListMeta$$]__ | Refer to Kubernetes API documentation for fields of `metadata`.
 
-| *`items`* __xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-check[$$Check$$] array__ | 
+| *`items`* __xref:{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-check[$$Check$$] array__ | 
 |===
 
 
-[id="{anchor_prefix}-github-com-k8up-io-k8up-api-v1-checkschedule"]
+[id="{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-checkschedule"]
 === CheckSchedule 
 
 CheckSchedule manages the schedules for the checks
 
 .Appears In:
 ****
-- xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-schedulespec[$$ScheduleSpec$$]
+- xref:{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-schedulespec[$$ScheduleSpec$$]
 ****
 
 [cols="25a,75a", options="header"]
 |===
 | Field | Description
-| *`CheckSpec`* __xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-checkspec[$$CheckSpec$$]__ | 
-| *`ScheduleCommon`* __xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-schedulecommon[$$ScheduleCommon$$]__ | 
+| *`CheckSpec`* __xref:{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-checkspec[$$CheckSpec$$]__ | 
+| *`ScheduleCommon`* __xref:{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-schedulecommon[$$ScheduleCommon$$]__ | 
 |===
 
 
-[id="{anchor_prefix}-github-com-k8up-io-k8up-api-v1-checkspec"]
+[id="{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-checkspec"]
 === CheckSpec 
 
 CheckSpec defines the desired state of Check. It needs to contain the repository information.
 
 .Appears In:
 ****
-- xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-check[$$Check$$]
-- xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-checkschedule[$$CheckSchedule$$]
+- xref:{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-check[$$Check$$]
+- xref:{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-checkschedule[$$CheckSchedule$$]
 ****
 
 [cols="25a,75a", options="header"]
 |===
 | Field | Description
-| *`RunnableSpec`* __xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-runnablespec[$$RunnableSpec$$]__ | 
+| *`RunnableSpec`* __xref:{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-runnablespec[$$RunnableSpec$$]__ | 
 | *`promURL`* __string__ | PromURL sets a prometheus push URL where the backup container send metrics to
 | *`keepJobs`* __integer__ | KeepJobs amount of jobs to keep for later analysis. 
  Deprecated: Use FailedJobsHistoryLimit and SuccessfulJobsHistoryLimit respectively.
@@ -330,14 +330,14 @@ CheckSpec defines the desired state of Check. It needs to contain the repository
 |===
 
 
-[id="{anchor_prefix}-github-com-k8up-io-k8up-api-v1-effectiveschedule"]
+[id="{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-effectiveschedule"]
 === EffectiveSchedule 
 
 EffectiveSchedule is the Schema to persist schedules generated from Randomized schedules.
 
 .Appears In:
 ****
-- xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-effectiveschedulelist[$$EffectiveScheduleList$$]
+- xref:{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-effectiveschedulelist[$$EffectiveScheduleList$$]
 ****
 
 [cols="25a,75a", options="header"]
@@ -347,11 +347,11 @@ EffectiveSchedule is the Schema to persist schedules generated from Randomized s
 | *`kind`* __string__ | `EffectiveSchedule`
 | *`metadata`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#objectmeta-v1-meta[$$ObjectMeta$$]__ | Refer to Kubernetes API documentation for fields of `metadata`.
 
-| *`spec`* __xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-effectiveschedulespec[$$EffectiveScheduleSpec$$]__ | 
+| *`spec`* __xref:{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-effectiveschedulespec[$$EffectiveScheduleSpec$$]__ | 
 |===
 
 
-[id="{anchor_prefix}-github-com-k8up-io-k8up-api-v1-effectiveschedulelist"]
+[id="{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-effectiveschedulelist"]
 === EffectiveScheduleList 
 
 EffectiveScheduleList contains a list of EffectiveSchedule
@@ -365,38 +365,38 @@ EffectiveScheduleList contains a list of EffectiveSchedule
 | *`kind`* __string__ | `EffectiveScheduleList`
 | *`metadata`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#listmeta-v1-meta[$$ListMeta$$]__ | Refer to Kubernetes API documentation for fields of `metadata`.
 
-| *`items`* __xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-effectiveschedule[$$EffectiveSchedule$$] array__ | 
+| *`items`* __xref:{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-effectiveschedule[$$EffectiveSchedule$$] array__ | 
 |===
 
 
-[id="{anchor_prefix}-github-com-k8up-io-k8up-api-v1-effectiveschedulespec"]
+[id="{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-effectiveschedulespec"]
 === EffectiveScheduleSpec 
 
 EffectiveScheduleSpec defines the desired state of EffectiveSchedule
 
 .Appears In:
 ****
-- xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-effectiveschedule[$$EffectiveSchedule$$]
+- xref:{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-effectiveschedule[$$EffectiveSchedule$$]
 ****
 
 [cols="25a,75a", options="header"]
 |===
 | Field | Description
-| *`generatedSchedule`* __xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-scheduledefinition[$$ScheduleDefinition$$]__ | GeneratedSchedule is the effective schedule that is added to Cron
-| *`originalSchedule`* __xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-scheduledefinition[$$ScheduleDefinition$$]__ | OriginalSchedule is the original user-defined schedule definition in the Schedule object.
+| *`generatedSchedule`* __xref:{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-scheduledefinition[$$ScheduleDefinition$$]__ | GeneratedSchedule is the effective schedule that is added to Cron
+| *`originalSchedule`* __xref:{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-scheduledefinition[$$ScheduleDefinition$$]__ | OriginalSchedule is the original user-defined schedule definition in the Schedule object.
 | *`jobType`* __JobType__ | JobType defines to which job type this schedule applies
-| *`scheduleRefs`* __xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-scheduleref[$$ScheduleRef$$] array__ | ScheduleRefs holds a list of schedules for which the generated schedule applies to. The list may omit entries that aren't generated from smart schedules.
+| *`scheduleRefs`* __xref:{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-scheduleref[$$ScheduleRef$$] array__ | ScheduleRefs holds a list of schedules for which the generated schedule applies to. The list may omit entries that aren't generated from smart schedules.
 |===
 
 
-[id="{anchor_prefix}-github-com-k8up-io-k8up-api-v1-env"]
+[id="{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-env"]
 === Env 
 
 
 
 .Appears In:
 ****
-- xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-backuptemplate[$$BackupTemplate$$]
+- xref:{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-backuptemplate[$$BackupTemplate$$]
 ****
 
 [cols="25a,75a", options="header"]
@@ -407,14 +407,14 @@ EffectiveScheduleSpec defines the desired state of EffectiveSchedule
 |===
 
 
-[id="{anchor_prefix}-github-com-k8up-io-k8up-api-v1-folderrestore"]
+[id="{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-folderrestore"]
 === FolderRestore 
 
 
 
 .Appears In:
 ****
-- xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-restoremethod[$$RestoreMethod$$]
+- xref:{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-restoremethod[$$RestoreMethod$$]
 ****
 
 [cols="25a,75a", options="header"]
@@ -424,14 +424,14 @@ EffectiveScheduleSpec defines the desired state of EffectiveSchedule
 |===
 
 
-[id="{anchor_prefix}-github-com-k8up-io-k8up-api-v1-gcsspec"]
+[id="{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-gcsspec"]
 === GCSSpec 
 
 
 
 .Appears In:
 ****
-- xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-backend[$$Backend$$]
+- xref:{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-backend[$$Backend$$]
 ****
 
 
@@ -440,28 +440,28 @@ EffectiveScheduleSpec defines the desired state of EffectiveSchedule
 
 
 
-[id="{anchor_prefix}-github-com-k8up-io-k8up-api-v1-localspec"]
+[id="{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-localspec"]
 === LocalSpec 
 
 
 
 .Appears In:
 ****
-- xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-backend[$$Backend$$]
+- xref:{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-backend[$$Backend$$]
 ****
 
 
 
 
 
-[id="{anchor_prefix}-github-com-k8up-io-k8up-api-v1-pod"]
+[id="{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-pod"]
 === Pod 
 
 Pod is a dummy struct to fix some code generation issues.
 
 .Appears In:
 ****
-- xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-prebackuppodspec[$$PreBackupPodSpec$$]
+- xref:{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-prebackuppodspec[$$PreBackupPodSpec$$]
 ****
 
 [cols="25a,75a", options="header"]
@@ -471,14 +471,14 @@ Pod is a dummy struct to fix some code generation issues.
 |===
 
 
-[id="{anchor_prefix}-github-com-k8up-io-k8up-api-v1-prebackuppod"]
+[id="{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-prebackuppod"]
 === PreBackupPod 
 
 PreBackupPod is the Schema for the prebackuppods API
 
 .Appears In:
 ****
-- xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-prebackuppodlist[$$PreBackupPodList$$]
+- xref:{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-prebackuppodlist[$$PreBackupPodList$$]
 ****
 
 [cols="25a,75a", options="header"]
@@ -488,11 +488,11 @@ PreBackupPod is the Schema for the prebackuppods API
 | *`kind`* __string__ | `PreBackupPod`
 | *`metadata`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#objectmeta-v1-meta[$$ObjectMeta$$]__ | Refer to Kubernetes API documentation for fields of `metadata`.
 
-| *`spec`* __xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-prebackuppodspec[$$PreBackupPodSpec$$]__ | 
+| *`spec`* __xref:{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-prebackuppodspec[$$PreBackupPodSpec$$]__ | 
 |===
 
 
-[id="{anchor_prefix}-github-com-k8up-io-k8up-api-v1-prebackuppodlist"]
+[id="{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-prebackuppodlist"]
 === PreBackupPodList 
 
 PreBackupPodList contains a list of PreBackupPod
@@ -506,18 +506,18 @@ PreBackupPodList contains a list of PreBackupPod
 | *`kind`* __string__ | `PreBackupPodList`
 | *`metadata`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#listmeta-v1-meta[$$ListMeta$$]__ | Refer to Kubernetes API documentation for fields of `metadata`.
 
-| *`items`* __xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-prebackuppod[$$PreBackupPod$$] array__ | 
+| *`items`* __xref:{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-prebackuppod[$$PreBackupPod$$] array__ | 
 |===
 
 
-[id="{anchor_prefix}-github-com-k8up-io-k8up-api-v1-prebackuppodspec"]
+[id="{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-prebackuppodspec"]
 === PreBackupPodSpec 
 
 PreBackupPodSpec define pods that will be launched during the backup. After the backup has finished (successfully or not), they should be removed again automatically by the operator.
 
 .Appears In:
 ****
-- xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-prebackuppod[$$PreBackupPod$$]
+- xref:{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-prebackuppod[$$PreBackupPod$$]
 ****
 
 [cols="25a,75a", options="header"]
@@ -525,18 +525,18 @@ PreBackupPodSpec define pods that will be launched during the backup. After the 
 | Field | Description
 | *`backupCommand`* __string__ | BackupCommand will be added to the backupcommand annotation on the pod.
 | *`fileExtension`* __string__ | 
-| *`pod`* __xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-pod[$$Pod$$]__ | 
+| *`pod`* __xref:{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-pod[$$Pod$$]__ | 
 |===
 
 
-[id="{anchor_prefix}-github-com-k8up-io-k8up-api-v1-prune"]
+[id="{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-prune"]
 === Prune 
 
 Prune is the Schema for the prunes API
 
 .Appears In:
 ****
-- xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-prunelist[$$PruneList$$]
+- xref:{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-prunelist[$$PruneList$$]
 ****
 
 [cols="25a,75a", options="header"]
@@ -546,11 +546,11 @@ Prune is the Schema for the prunes API
 | *`kind`* __string__ | `Prune`
 | *`metadata`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#objectmeta-v1-meta[$$ObjectMeta$$]__ | Refer to Kubernetes API documentation for fields of `metadata`.
 
-| *`spec`* __xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-prunespec[$$PruneSpec$$]__ | 
+| *`spec`* __xref:{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-prunespec[$$PruneSpec$$]__ | 
 |===
 
 
-[id="{anchor_prefix}-github-com-k8up-io-k8up-api-v1-prunelist"]
+[id="{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-prunelist"]
 === PruneList 
 
 PruneList contains a list of Prune
@@ -564,44 +564,44 @@ PruneList contains a list of Prune
 | *`kind`* __string__ | `PruneList`
 | *`metadata`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#listmeta-v1-meta[$$ListMeta$$]__ | Refer to Kubernetes API documentation for fields of `metadata`.
 
-| *`items`* __xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-prune[$$Prune$$] array__ | 
+| *`items`* __xref:{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-prune[$$Prune$$] array__ | 
 |===
 
 
-[id="{anchor_prefix}-github-com-k8up-io-k8up-api-v1-pruneschedule"]
+[id="{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-pruneschedule"]
 === PruneSchedule 
 
 PruneSchedule manages the schedules for the prunes
 
 .Appears In:
 ****
-- xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-schedulespec[$$ScheduleSpec$$]
+- xref:{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-schedulespec[$$ScheduleSpec$$]
 ****
 
 [cols="25a,75a", options="header"]
 |===
 | Field | Description
-| *`PruneSpec`* __xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-prunespec[$$PruneSpec$$]__ | 
-| *`ScheduleCommon`* __xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-schedulecommon[$$ScheduleCommon$$]__ | 
+| *`PruneSpec`* __xref:{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-prunespec[$$PruneSpec$$]__ | 
+| *`ScheduleCommon`* __xref:{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-schedulecommon[$$ScheduleCommon$$]__ | 
 |===
 
 
-[id="{anchor_prefix}-github-com-k8up-io-k8up-api-v1-prunespec"]
+[id="{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-prunespec"]
 === PruneSpec 
 
 PruneSpec needs to contain the repository information as well as the desired retention policies.
 
 .Appears In:
 ****
-- xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-prune[$$Prune$$]
-- xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-pruneschedule[$$PruneSchedule$$]
+- xref:{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-prune[$$Prune$$]
+- xref:{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-pruneschedule[$$PruneSchedule$$]
 ****
 
 [cols="25a,75a", options="header"]
 |===
 | Field | Description
-| *`RunnableSpec`* __xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-runnablespec[$$RunnableSpec$$]__ | 
-| *`retention`* __xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-retentionpolicy[$$RetentionPolicy$$]__ | Retention sets how many backups should be kept after a forget and prune
+| *`RunnableSpec`* __xref:{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-runnablespec[$$RunnableSpec$$]__ | 
+| *`retention`* __xref:{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-retentionpolicy[$$RetentionPolicy$$]__ | Retention sets how many backups should be kept after a forget and prune
 | *`keepJobs`* __integer__ | KeepJobs amount of jobs to keep for later analysis. 
  Deprecated: Use FailedJobsHistoryLimit and SuccessfulJobsHistoryLimit respectively.
 | *`failedJobsHistoryLimit`* __integer__ | FailedJobsHistoryLimit amount of failed jobs to keep for later analysis. KeepJobs is used property is not specified.
@@ -609,26 +609,26 @@ PruneSpec needs to contain the repository information as well as the desired ret
 |===
 
 
-[id="{anchor_prefix}-github-com-k8up-io-k8up-api-v1-restserverspec"]
+[id="{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-restserverspec"]
 === RestServerSpec 
 
 
 
 .Appears In:
 ****
-- xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-backend[$$Backend$$]
+- xref:{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-backend[$$Backend$$]
 ****
 
 
 
-[id="{anchor_prefix}-github-com-k8up-io-k8up-api-v1-restore"]
+[id="{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-restore"]
 === Restore 
 
 Restore is the Schema for the restores API
 
 .Appears In:
 ****
-- xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-restorelist[$$RestoreList$$]
+- xref:{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-restorelist[$$RestoreList$$]
 ****
 
 [cols="25a,75a", options="header"]
@@ -638,11 +638,11 @@ Restore is the Schema for the restores API
 | *`kind`* __string__ | `Restore`
 | *`metadata`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#objectmeta-v1-meta[$$ObjectMeta$$]__ | Refer to Kubernetes API documentation for fields of `metadata`.
 
-| *`spec`* __xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-restorespec[$$RestoreSpec$$]__ | 
+| *`spec`* __xref:{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-restorespec[$$RestoreSpec$$]__ | 
 |===
 
 
-[id="{anchor_prefix}-github-com-k8up-io-k8up-api-v1-restorelist"]
+[id="{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-restorelist"]
 === RestoreList 
 
 RestoreList contains a list of Restore
@@ -656,63 +656,63 @@ RestoreList contains a list of Restore
 | *`kind`* __string__ | `RestoreList`
 | *`metadata`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#listmeta-v1-meta[$$ListMeta$$]__ | Refer to Kubernetes API documentation for fields of `metadata`.
 
-| *`items`* __xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-restore[$$Restore$$] array__ | 
+| *`items`* __xref:{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-restore[$$Restore$$] array__ | 
 |===
 
 
-[id="{anchor_prefix}-github-com-k8up-io-k8up-api-v1-restoremethod"]
+[id="{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-restoremethod"]
 === RestoreMethod 
 
 RestoreMethod contains how and where the restore should happen all the settings are mutual exclusive.
 
 .Appears In:
 ****
-- xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-restorespec[$$RestoreSpec$$]
+- xref:{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-restorespec[$$RestoreSpec$$]
 ****
 
 [cols="25a,75a", options="header"]
 |===
 | Field | Description
-| *`s3`* __xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-s3spec[$$S3Spec$$]__ | 
-| *`folder`* __xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-folderrestore[$$FolderRestore$$]__ | 
+| *`s3`* __xref:{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-s3spec[$$S3Spec$$]__ | 
+| *`folder`* __xref:{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-folderrestore[$$FolderRestore$$]__ | 
 |===
 
 
-[id="{anchor_prefix}-github-com-k8up-io-k8up-api-v1-restoreschedule"]
+[id="{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-restoreschedule"]
 === RestoreSchedule 
 
 RestoreSchedule manages schedules for the restore service
 
 .Appears In:
 ****
-- xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-schedulespec[$$ScheduleSpec$$]
+- xref:{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-schedulespec[$$ScheduleSpec$$]
 ****
 
 [cols="25a,75a", options="header"]
 |===
 | Field | Description
-| *`RestoreSpec`* __xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-restorespec[$$RestoreSpec$$]__ | 
-| *`ScheduleCommon`* __xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-schedulecommon[$$ScheduleCommon$$]__ | 
+| *`RestoreSpec`* __xref:{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-restorespec[$$RestoreSpec$$]__ | 
+| *`ScheduleCommon`* __xref:{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-schedulecommon[$$ScheduleCommon$$]__ | 
 |===
 
 
-[id="{anchor_prefix}-github-com-k8up-io-k8up-api-v1-restorespec"]
+[id="{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-restorespec"]
 === RestoreSpec 
 
 RestoreSpec can either contain an S3 restore point or a local one. For the local one you need to define an existing PVC.
 
 .Appears In:
 ****
-- xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-archivespec[$$ArchiveSpec$$]
-- xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-restore[$$Restore$$]
-- xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-restoreschedule[$$RestoreSchedule$$]
+- xref:{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-archivespec[$$ArchiveSpec$$]
+- xref:{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-restore[$$Restore$$]
+- xref:{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-restoreschedule[$$RestoreSchedule$$]
 ****
 
 [cols="25a,75a", options="header"]
 |===
 | Field | Description
-| *`RunnableSpec`* __xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-runnablespec[$$RunnableSpec$$]__ | 
-| *`restoreMethod`* __xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-restoremethod[$$RestoreMethod$$]__ | 
+| *`RunnableSpec`* __xref:{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-runnablespec[$$RunnableSpec$$]__ | 
+| *`restoreMethod`* __xref:{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-restoremethod[$$RestoreMethod$$]__ | 
 | *`restoreFilter`* __string__ | 
 | *`snapshot`* __string__ | 
 | *`keepJobs`* __integer__ | KeepJobs amount of jobs to keep for later analysis. 
@@ -723,14 +723,14 @@ RestoreSpec can either contain an S3 restore point or a local one. For the local
 |===
 
 
-[id="{anchor_prefix}-github-com-k8up-io-k8up-api-v1-retentionpolicy"]
+[id="{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-retentionpolicy"]
 === RetentionPolicy 
 
 
 
 .Appears In:
 ****
-- xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-prunespec[$$PruneSpec$$]
+- xref:{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-prunespec[$$PruneSpec$$]
 ****
 
 [cols="25a,75a", options="header"]
@@ -748,49 +748,49 @@ RestoreSpec can either contain an S3 restore point or a local one. For the local
 |===
 
 
-[id="{anchor_prefix}-github-com-k8up-io-k8up-api-v1-runnablespec"]
+[id="{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-runnablespec"]
 === RunnableSpec 
 
 RunnableSpec defines the fields that are necessary on the specs of all actions that are translated to k8s jobs eventually.
 
 .Appears In:
 ****
-- xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-backupspec[$$BackupSpec$$]
-- xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-checkspec[$$CheckSpec$$]
-- xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-prunespec[$$PruneSpec$$]
-- xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-restorespec[$$RestoreSpec$$]
+- xref:{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-backupspec[$$BackupSpec$$]
+- xref:{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-checkspec[$$CheckSpec$$]
+- xref:{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-prunespec[$$PruneSpec$$]
+- xref:{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-restorespec[$$RestoreSpec$$]
 ****
 
 [cols="25a,75a", options="header"]
 |===
 | Field | Description
-| *`backend`* __xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-backend[$$Backend$$]__ | Backend contains the restic repo where the job should backup to.
+| *`backend`* __xref:{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-backend[$$Backend$$]__ | Backend contains the restic repo where the job should backup to.
 | *`resources`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#resourcerequirements-v1-core[$$ResourceRequirements$$]__ | Resources describes the compute resource requirements (cpu, memory, etc.)
 | *`podSecurityContext`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#podsecuritycontext-v1-core[$$PodSecurityContext$$]__ | PodSecurityContext describes the security context with which this action shall be executed.
 |===
 
 
-[id="{anchor_prefix}-github-com-k8up-io-k8up-api-v1-s3spec"]
+[id="{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-s3spec"]
 === S3Spec 
 
 
 
 .Appears In:
 ****
-- xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-backend[$$Backend$$]
-- xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-restoremethod[$$RestoreMethod$$]
+- xref:{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-backend[$$Backend$$]
+- xref:{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-restoremethod[$$RestoreMethod$$]
 ****
 
 
 
-[id="{anchor_prefix}-github-com-k8up-io-k8up-api-v1-schedule"]
+[id="{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-schedule"]
 === Schedule 
 
 Schedule is the Schema for the schedules API
 
 .Appears In:
 ****
-- xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-schedulelist[$$ScheduleList$$]
+- xref:{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-schedulelist[$$ScheduleList$$]
 ****
 
 [cols="25a,75a", options="header"]
@@ -800,46 +800,46 @@ Schedule is the Schema for the schedules API
 | *`kind`* __string__ | `Schedule`
 | *`metadata`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#objectmeta-v1-meta[$$ObjectMeta$$]__ | Refer to Kubernetes API documentation for fields of `metadata`.
 
-| *`spec`* __xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-schedulespec[$$ScheduleSpec$$]__ | 
+| *`spec`* __xref:{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-schedulespec[$$ScheduleSpec$$]__ | 
 |===
 
 
-[id="{anchor_prefix}-github-com-k8up-io-k8up-api-v1-schedulecommon"]
+[id="{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-schedulecommon"]
 === ScheduleCommon 
 
 ScheduleCommon contains fields every schedule needs
 
 .Appears In:
 ****
-- xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-archiveschedule[$$ArchiveSchedule$$]
-- xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-backupschedule[$$BackupSchedule$$]
-- xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-checkschedule[$$CheckSchedule$$]
-- xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-pruneschedule[$$PruneSchedule$$]
-- xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-restoreschedule[$$RestoreSchedule$$]
+- xref:{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-archiveschedule[$$ArchiveSchedule$$]
+- xref:{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-backupschedule[$$BackupSchedule$$]
+- xref:{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-checkschedule[$$CheckSchedule$$]
+- xref:{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-pruneschedule[$$PruneSchedule$$]
+- xref:{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-restoreschedule[$$RestoreSchedule$$]
 ****
 
 [cols="25a,75a", options="header"]
 |===
 | Field | Description
-| *`schedule`* __xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-scheduledefinition[$$ScheduleDefinition$$]__ | 
+| *`schedule`* __xref:{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-scheduledefinition[$$ScheduleDefinition$$]__ | 
 | *`concurrentRunsAllowed`* __boolean__ | 
 |===
 
 
-[id="{anchor_prefix}-github-com-k8up-io-k8up-api-v1-scheduledefinition"]
+[id="{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-scheduledefinition"]
 === ScheduleDefinition (string) 
 
 ScheduleDefinition is the actual cron-type expression that defines the interval of the actions.
 
 .Appears In:
 ****
-- xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-effectiveschedulespec[$$EffectiveScheduleSpec$$]
-- xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-schedulecommon[$$ScheduleCommon$$]
+- xref:{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-effectiveschedulespec[$$EffectiveScheduleSpec$$]
+- xref:{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-schedulecommon[$$ScheduleCommon$$]
 ****
 
 
 
-[id="{anchor_prefix}-github-com-k8up-io-k8up-api-v1-schedulelist"]
+[id="{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-schedulelist"]
 === ScheduleList 
 
 ScheduleList contains a list of Schedule
@@ -853,18 +853,18 @@ ScheduleList contains a list of Schedule
 | *`kind`* __string__ | `ScheduleList`
 | *`metadata`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#listmeta-v1-meta[$$ListMeta$$]__ | Refer to Kubernetes API documentation for fields of `metadata`.
 
-| *`items`* __xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-schedule[$$Schedule$$] array__ | 
+| *`items`* __xref:{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-schedule[$$Schedule$$] array__ | 
 |===
 
 
-[id="{anchor_prefix}-github-com-k8up-io-k8up-api-v1-scheduleref"]
+[id="{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-scheduleref"]
 === ScheduleRef 
 
 ScheduleRef represents a reference to a Schedule resource
 
 .Appears In:
 ****
-- xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-effectiveschedulespec[$$EffectiveScheduleSpec$$]
+- xref:{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-effectiveschedulespec[$$EffectiveScheduleSpec$$]
 ****
 
 [cols="25a,75a", options="header"]
@@ -875,25 +875,25 @@ ScheduleRef represents a reference to a Schedule resource
 |===
 
 
-[id="{anchor_prefix}-github-com-k8up-io-k8up-api-v1-schedulespec"]
+[id="{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-schedulespec"]
 === ScheduleSpec 
 
 ScheduleSpec defines the schedules for the various job types.
 
 .Appears In:
 ****
-- xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-schedule[$$Schedule$$]
+- xref:{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-schedule[$$Schedule$$]
 ****
 
 [cols="25a,75a", options="header"]
 |===
 | Field | Description
-| *`restore`* __xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-restoreschedule[$$RestoreSchedule$$]__ | 
-| *`backup`* __xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-backupschedule[$$BackupSchedule$$]__ | 
-| *`archive`* __xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-archiveschedule[$$ArchiveSchedule$$]__ | 
-| *`check`* __xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-checkschedule[$$CheckSchedule$$]__ | 
-| *`prune`* __xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-pruneschedule[$$PruneSchedule$$]__ | 
-| *`backend`* __xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-backend[$$Backend$$]__ | 
+| *`restore`* __xref:{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-restoreschedule[$$RestoreSchedule$$]__ | 
+| *`backup`* __xref:{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-backupschedule[$$BackupSchedule$$]__ | 
+| *`archive`* __xref:{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-archiveschedule[$$ArchiveSchedule$$]__ | 
+| *`check`* __xref:{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-checkschedule[$$CheckSchedule$$]__ | 
+| *`prune`* __xref:{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-pruneschedule[$$PruneSchedule$$]__ | 
+| *`backend`* __xref:{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-backend[$$Backend$$]__ | 
 | *`keepJobs`* __integer__ | KeepJobs amount of jobs to keep for later analysis. 
  Deprecated: Use FailedJobsHistoryLimit and SuccessfulJobsHistoryLimit respectively.
 | *`failedJobsHistoryLimit`* __integer__ | FailedJobsHistoryLimit amount of failed jobs to keep for later analysis. KeepJobs is used property is not specified.
@@ -907,14 +907,14 @@ ScheduleSpec defines the schedules for the various job types.
 
 
 
-[id="{anchor_prefix}-github-com-k8up-io-k8up-api-v1-snapshot"]
+[id="{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-snapshot"]
 === Snapshot 
 
 Snapshot is the Schema for the snapshots API
 
 .Appears In:
 ****
-- xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-snapshotlist[$$SnapshotList$$]
+- xref:{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-snapshotlist[$$SnapshotList$$]
 ****
 
 [cols="25a,75a", options="header"]
@@ -924,11 +924,11 @@ Snapshot is the Schema for the snapshots API
 | *`kind`* __string__ | `Snapshot`
 | *`metadata`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#objectmeta-v1-meta[$$ObjectMeta$$]__ | Refer to Kubernetes API documentation for fields of `metadata`.
 
-| *`spec`* __xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-snapshotspec[$$SnapshotSpec$$]__ | 
+| *`spec`* __xref:{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-snapshotspec[$$SnapshotSpec$$]__ | 
 |===
 
 
-[id="{anchor_prefix}-github-com-k8up-io-k8up-api-v1-snapshotlist"]
+[id="{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-snapshotlist"]
 === SnapshotList 
 
 SnapshotList contains a list of Snapshot
@@ -942,18 +942,18 @@ SnapshotList contains a list of Snapshot
 | *`kind`* __string__ | `SnapshotList`
 | *`metadata`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#listmeta-v1-meta[$$ListMeta$$]__ | Refer to Kubernetes API documentation for fields of `metadata`.
 
-| *`items`* __xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-snapshot[$$Snapshot$$] array__ | 
+| *`items`* __xref:{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-snapshot[$$Snapshot$$] array__ | 
 |===
 
 
-[id="{anchor_prefix}-github-com-k8up-io-k8up-api-v1-snapshotspec"]
+[id="{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-snapshotspec"]
 === SnapshotSpec 
 
 SnapshotSpec contains all information needed about a restic snapshot so it can be restored.
 
 .Appears In:
 ****
-- xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-snapshot[$$Snapshot$$]
+- xref:{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-snapshot[$$Snapshot$$]
 ****
 
 [cols="25a,75a", options="header"]
@@ -969,14 +969,14 @@ SnapshotSpec contains all information needed about a restic snapshot so it can b
 
 
 
-[id="{anchor_prefix}-github-com-k8up-io-k8up-api-v1-swiftspec"]
+[id="{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-swiftspec"]
 === SwiftSpec 
 
 
 
 .Appears In:
 ****
-- xref:{anchor_prefix}-github-com-k8up-io-k8up-api-v1-backend[$$Backend$$]
+- xref:{anchor_prefix}-github-com-k8up-io-k8up-v2-api-v1-backend[$$Backend$$]
 ****
 
 

--- a/envtest/envsuite.go
+++ b/envtest/envsuite.go
@@ -33,9 +33,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	// +kubebuilder:scaffold:imports
 
-	k8upv1 "github.com/k8up-io/k8up/api/v1"
-	"github.com/k8up-io/k8up/operator/cfg"
-	"github.com/k8up-io/k8up/operator/executor"
+	k8upv1 "github.com/k8up-io/k8up/v2/api/v1"
+	"github.com/k8up-io/k8up/v2/operator/cfg"
+	"github.com/k8up-io/k8up/v2/operator/executor"
 )
 
 var InvalidNSNameCharacters = regexp.MustCompile("[^a-z0-9-]")

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/k8up-io/k8up
+module github.com/k8up-io/k8up/v2
 
 go 1.17
 

--- a/operator/executor/archive.go
+++ b/operator/executor/archive.go
@@ -8,10 +8,10 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 
-	k8upv1 "github.com/k8up-io/k8up/api/v1"
-	"github.com/k8up-io/k8up/operator/cfg"
-	"github.com/k8up-io/k8up/operator/job"
-	"github.com/k8up-io/k8up/operator/observer"
+	k8upv1 "github.com/k8up-io/k8up/v2/api/v1"
+	"github.com/k8up-io/k8up/v2/operator/cfg"
+	"github.com/k8up-io/k8up/v2/operator/job"
+	"github.com/k8up-io/k8up/v2/operator/observer"
 )
 
 const archivePath = "/archive"

--- a/operator/executor/backup.go
+++ b/operator/executor/backup.go
@@ -8,9 +8,9 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 
-	k8upv1 "github.com/k8up-io/k8up/api/v1"
-	"github.com/k8up-io/k8up/operator/cfg"
-	"github.com/k8up-io/k8up/operator/job"
+	k8upv1 "github.com/k8up-io/k8up/v2/api/v1"
+	"github.com/k8up-io/k8up/v2/operator/cfg"
+	"github.com/k8up-io/k8up/v2/operator/job"
 )
 
 // BackupExecutor creates a batch.job object on the cluster. It merges all the

--- a/operator/executor/backup_utils.go
+++ b/operator/executor/backup_utils.go
@@ -8,8 +8,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/k8up-io/k8up/operator/cfg"
-	"github.com/k8up-io/k8up/operator/observer"
+	"github.com/k8up-io/k8up/v2/operator/cfg"
+	"github.com/k8up-io/k8up/v2/operator/observer"
 )
 
 func (b *BackupExecutor) fetchPVCs(list client.ObjectList) error {

--- a/operator/executor/backup_utils_test.go
+++ b/operator/executor/backup_utils_test.go
@@ -4,9 +4,9 @@ import (
 	"testing"
 
 	"github.com/go-logr/zapr"
-	v1 "github.com/k8up-io/k8up/api/v1"
-	"github.com/k8up-io/k8up/operator/cfg"
-	"github.com/k8up-io/k8up/operator/job"
+	v1 "github.com/k8up-io/k8up/v2/api/v1"
+	"github.com/k8up-io/k8up/v2/operator/cfg"
+	"github.com/k8up-io/k8up/v2/operator/job"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap/zaptest"
 	corev1 "k8s.io/api/core/v1"

--- a/operator/executor/check.go
+++ b/operator/executor/check.go
@@ -7,10 +7,10 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 
-	k8upv1 "github.com/k8up-io/k8up/api/v1"
-	"github.com/k8up-io/k8up/operator/cfg"
-	"github.com/k8up-io/k8up/operator/job"
-	"github.com/k8up-io/k8up/operator/observer"
+	k8upv1 "github.com/k8up-io/k8up/v2/api/v1"
+	"github.com/k8up-io/k8up/v2/operator/cfg"
+	"github.com/k8up-io/k8up/v2/operator/job"
+	"github.com/k8up-io/k8up/v2/operator/observer"
 )
 
 // CheckExecutor will execute the batch.job for checks.

--- a/operator/executor/cleaner/cleaner.go
+++ b/operator/executor/cleaner/cleaner.go
@@ -10,9 +10,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	k8upv1 "github.com/k8up-io/k8up/api/v1"
-	"github.com/k8up-io/k8up/operator/cfg"
-	"github.com/k8up-io/k8up/operator/job"
+	k8upv1 "github.com/k8up-io/k8up/v2/api/v1"
+	"github.com/k8up-io/k8up/v2/operator/cfg"
+	"github.com/k8up-io/k8up/v2/operator/job"
 )
 
 // ObjectCleaner cleans old, finished job objects.

--- a/operator/executor/cleaner/cleaner_integration_test.go
+++ b/operator/executor/cleaner/cleaner_integration_test.go
@@ -6,10 +6,10 @@ package cleaner_test
 import (
 	"testing"
 
-	k8upv1 "github.com/k8up-io/k8up/api/v1"
-	"github.com/k8up-io/k8up/envtest"
-	"github.com/k8up-io/k8up/operator/executor/cleaner"
-	"github.com/k8up-io/k8up/operator/job"
+	k8upv1 "github.com/k8up-io/k8up/v2/api/v1"
+	"github.com/k8up-io/k8up/v2/envtest"
+	"github.com/k8up-io/k8up/v2/operator/executor/cleaner"
+	"github.com/k8up-io/k8up/v2/operator/job"
 	"github.com/stretchr/testify/suite"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/uuid"

--- a/operator/executor/generic.go
+++ b/operator/executor/generic.go
@@ -14,12 +14,12 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	k8upv1 "github.com/k8up-io/k8up/api/v1"
-	"github.com/k8up-io/k8up/operator/cfg"
-	"github.com/k8up-io/k8up/operator/executor/cleaner"
-	"github.com/k8up-io/k8up/operator/job"
-	"github.com/k8up-io/k8up/operator/observer"
-	"github.com/k8up-io/k8up/operator/queue"
+	k8upv1 "github.com/k8up-io/k8up/v2/api/v1"
+	"github.com/k8up-io/k8up/v2/operator/cfg"
+	"github.com/k8up-io/k8up/v2/operator/executor/cleaner"
+	"github.com/k8up-io/k8up/v2/operator/job"
+	"github.com/k8up-io/k8up/v2/operator/observer"
+	"github.com/k8up-io/k8up/v2/operator/queue"
 )
 
 type generic struct {

--- a/operator/executor/prebackup.go
+++ b/operator/executor/prebackup.go
@@ -6,7 +6,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	k8upv1 "github.com/k8up-io/k8up/api/v1"
+	k8upv1 "github.com/k8up-io/k8up/v2/api/v1"
 )
 
 // StartPreBackup will start the defined pods as deployments.

--- a/operator/executor/prebackup_utils.go
+++ b/operator/executor/prebackup_utils.go
@@ -12,8 +12,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	k8upv1 "github.com/k8up-io/k8up/api/v1"
-	"github.com/k8up-io/k8up/operator/cfg"
+	k8upv1 "github.com/k8up-io/k8up/v2/api/v1"
+	"github.com/k8up-io/k8up/v2/operator/cfg"
 )
 
 // fetchPreBackupPodTemplates fetches all PreBackupPods from the same namespace as the originating backup.

--- a/operator/executor/prune.go
+++ b/operator/executor/prune.go
@@ -10,10 +10,10 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 
-	k8upv1 "github.com/k8up-io/k8up/api/v1"
-	"github.com/k8up-io/k8up/operator/cfg"
-	"github.com/k8up-io/k8up/operator/job"
-	"github.com/k8up-io/k8up/operator/observer"
+	k8upv1 "github.com/k8up-io/k8up/v2/api/v1"
+	"github.com/k8up-io/k8up/v2/operator/cfg"
+	"github.com/k8up-io/k8up/v2/operator/job"
+	"github.com/k8up-io/k8up/v2/operator/observer"
 )
 
 // PruneExecutor will execute the batch.job for Prunes.

--- a/operator/executor/restore.go
+++ b/operator/executor/restore.go
@@ -10,10 +10,10 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 
-	k8upv1 "github.com/k8up-io/k8up/api/v1"
-	"github.com/k8up-io/k8up/operator/cfg"
-	"github.com/k8up-io/k8up/operator/job"
-	"github.com/k8up-io/k8up/operator/observer"
+	k8upv1 "github.com/k8up-io/k8up/v2/api/v1"
+	"github.com/k8up-io/k8up/v2/operator/cfg"
+	"github.com/k8up-io/k8up/v2/operator/job"
+	"github.com/k8up-io/k8up/v2/operator/observer"
 )
 
 const restorePath = "/restore"

--- a/operator/executor/restore_test.go
+++ b/operator/executor/restore_test.go
@@ -10,8 +10,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
-	k8upv1 "github.com/k8up-io/k8up/api/v1"
-	"github.com/k8up-io/k8up/operator/job"
+	k8upv1 "github.com/k8up-io/k8up/v2/api/v1"
+	"github.com/k8up-io/k8up/v2/operator/job"
 )
 
 var (

--- a/operator/executor/worker.go
+++ b/operator/executor/worker.go
@@ -7,8 +7,8 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/errors"
 
-	"github.com/k8up-io/k8up/operator/observer"
-	"github.com/k8up-io/k8up/operator/queue"
+	"github.com/k8up-io/k8up/v2/operator/observer"
+	"github.com/k8up-io/k8up/v2/operator/queue"
 )
 
 var (

--- a/operator/handler/effectiveschedule.go
+++ b/operator/handler/effectiveschedule.go
@@ -9,8 +9,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/rand"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	k8upv1 "github.com/k8up-io/k8up/api/v1"
-	"github.com/k8up-io/k8up/operator/cfg"
+	k8upv1 "github.com/k8up-io/k8up/v2/api/v1"
+	"github.com/k8up-io/k8up/v2/operator/cfg"
 )
 
 func (s *ScheduleHandler) newEffectiveSchedule(jobType k8upv1.JobType) k8upv1.EffectiveSchedule {

--- a/operator/handler/effectiveschedule_test.go
+++ b/operator/handler/effectiveschedule_test.go
@@ -7,8 +7,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	k8upv1 "github.com/k8up-io/k8up/api/v1"
-	"github.com/k8up-io/k8up/operator/job"
+	k8upv1 "github.com/k8up-io/k8up/v2/api/v1"
+	"github.com/k8up-io/k8up/v2/operator/job"
 )
 
 func TestScheduleHandler_findExistingSchedule(t *testing.T) {

--- a/operator/handler/generic.go
+++ b/operator/handler/generic.go
@@ -1,9 +1,9 @@
 package handler
 
 import (
-	"github.com/k8up-io/k8up/operator/executor"
-	"github.com/k8up-io/k8up/operator/job"
-	"github.com/k8up-io/k8up/operator/queue"
+	"github.com/k8up-io/k8up/v2/operator/executor"
+	"github.com/k8up-io/k8up/v2/operator/job"
+	"github.com/k8up-io/k8up/v2/operator/queue"
 )
 
 // Handler is the generic job handler for most of the k8up jobs.

--- a/operator/handler/job.go
+++ b/operator/handler/job.go
@@ -8,9 +8,9 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	k8upv1 "github.com/k8up-io/k8up/api/v1"
-	"github.com/k8up-io/k8up/operator/job"
-	"github.com/k8up-io/k8up/operator/observer"
+	k8upv1 "github.com/k8up-io/k8up/v2/api/v1"
+	"github.com/k8up-io/k8up/v2/operator/job"
+	"github.com/k8up-io/k8up/v2/operator/observer"
 )
 
 const (

--- a/operator/handler/randomizer.go
+++ b/operator/handler/randomizer.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"math/big"
 
-	k8upv1 "github.com/k8up-io/k8up/api/v1"
+	k8upv1 "github.com/k8up-io/k8up/v2/api/v1"
 )
 
 const (

--- a/operator/handler/randomizer_test.go
+++ b/operator/handler/randomizer_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	k8upv1 "github.com/k8up-io/k8up/api/v1"
+	k8upv1 "github.com/k8up-io/k8up/v2/api/v1"
 )
 
 func Test_randomizeSchedule_VerifyCronSyntax(t *testing.T) {

--- a/operator/handler/schedule.go
+++ b/operator/handler/schedule.go
@@ -7,10 +7,10 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	k8upv1 "github.com/k8up-io/k8up/api/v1"
-	"github.com/k8up-io/k8up/operator/cfg"
-	"github.com/k8up-io/k8up/operator/job"
-	"github.com/k8up-io/k8up/operator/scheduler"
+	k8upv1 "github.com/k8up-io/k8up/v2/api/v1"
+	"github.com/k8up-io/k8up/v2/operator/cfg"
+	"github.com/k8up-io/k8up/v2/operator/job"
+	"github.com/k8up-io/k8up/v2/operator/scheduler"
 )
 
 // ScheduleHandler handles the reconciles for the schedules. Schedules are a special

--- a/operator/handler/schedule_test.go
+++ b/operator/handler/schedule_test.go
@@ -7,8 +7,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 
-	k8upv1 "github.com/k8up-io/k8up/api/v1"
-	"github.com/k8up-io/k8up/operator/cfg"
+	k8upv1 "github.com/k8up-io/k8up/v2/api/v1"
+	"github.com/k8up-io/k8up/v2/operator/cfg"
 )
 
 func TestScheduleHandler_mergeResourcesWithDefaults(t *testing.T) {

--- a/operator/job/job.go
+++ b/operator/job/job.go
@@ -5,8 +5,8 @@ package job
 import (
 	"context"
 
-	k8upv1 "github.com/k8up-io/k8up/api/v1"
-	"github.com/k8up-io/k8up/operator/cfg"
+	k8upv1 "github.com/k8up-io/k8up/v2/api/v1"
+	"github.com/k8up-io/k8up/v2/operator/cfg"
 
 	"github.com/go-logr/logr"
 	batchv1 "k8s.io/api/batch/v1"

--- a/operator/job/status.go
+++ b/operator/job/status.go
@@ -8,7 +8,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	k8upv1 "github.com/k8up-io/k8up/api/v1"
+	k8upv1 "github.com/k8up-io/k8up/v2/api/v1"
 )
 
 // SetConditionTrue tells the K8s controller at once that the status of the given Conditions is now "True"

--- a/operator/job/status_test.go
+++ b/operator/job/status_test.go
@@ -7,8 +7,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/uuid"
 
-	k8upv1 "github.com/k8up-io/k8up/api/v1"
-	"github.com/k8up-io/k8up/operator/job"
+	k8upv1 "github.com/k8up-io/k8up/v2/api/v1"
+	"github.com/k8up-io/k8up/v2/operator/job"
 )
 
 func TestGroupByStatus(t *testing.T) {

--- a/operator/observer/observer.go
+++ b/operator/observer/observer.go
@@ -13,7 +13,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
 
-	k8upv1 "github.com/k8up-io/k8up/api/v1"
+	k8upv1 "github.com/k8up-io/k8up/v2/api/v1"
 )
 
 const (

--- a/operator/observer/observer_test.go
+++ b/operator/observer/observer_test.go
@@ -10,7 +10,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 
-	k8upv1 "github.com/k8up-io/k8up/api/v1"
+	k8upv1 "github.com/k8up-io/k8up/v2/api/v1"
 )
 
 func TestObserver_IsConcurrentJobsLimitReached(t *testing.T) {

--- a/operator/queue/execution.go
+++ b/operator/queue/execution.go
@@ -12,7 +12,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
 
-	k8upv1 "github.com/k8up-io/k8up/api/v1"
+	k8upv1 "github.com/k8up-io/k8up/v2/api/v1"
 )
 
 var (

--- a/operator/queue/execution_test.go
+++ b/operator/queue/execution_test.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"testing"
 
-	k8upv1 "github.com/k8up-io/k8up/api/v1"
+	k8upv1 "github.com/k8up-io/k8up/v2/api/v1"
 
 	"github.com/go-logr/logr"
 )

--- a/operator/scheduler/scheduler.go
+++ b/operator/scheduler/scheduler.go
@@ -15,8 +15,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
 
-	k8upv1 "github.com/k8up-io/k8up/api/v1"
-	"github.com/k8up-io/k8up/operator/job"
+	k8upv1 "github.com/k8up-io/k8up/v2/api/v1"
+	"github.com/k8up-io/k8up/v2/operator/job"
 )
 
 type (

--- a/operator/scheduler/scheduler_test.go
+++ b/operator/scheduler/scheduler_test.go
@@ -10,8 +10,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/rand"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	k8upv1 "github.com/k8up-io/k8up/api/v1"
-	"github.com/k8up-io/k8up/operator/job"
+	k8upv1 "github.com/k8up-io/k8up/v2/api/v1"
+	"github.com/k8up-io/k8up/v2/operator/job"
 )
 
 func TestScheduler_SyncSchedules(t *testing.T) {

--- a/restic/cli/backup.go
+++ b/restic/cli/backup.go
@@ -9,9 +9,9 @@ import (
 
 	"github.com/go-logr/logr"
 
-	"github.com/k8up-io/k8up/restic/cfg"
-	"github.com/k8up-io/k8up/restic/kubernetes"
-	"github.com/k8up-io/k8up/restic/logging"
+	"github.com/k8up-io/k8up/v2/restic/cfg"
+	"github.com/k8up-io/k8up/v2/restic/kubernetes"
+	"github.com/k8up-io/k8up/v2/restic/logging"
 )
 
 // Backup backup to the repository. It will loop through all subfolders of

--- a/restic/cli/check.go
+++ b/restic/cli/check.go
@@ -1,7 +1,7 @@
 package cli
 
 import (
-	"github.com/k8up-io/k8up/restic/logging"
+	"github.com/k8up-io/k8up/v2/restic/logging"
 )
 
 // Check will check the repository for errors

--- a/restic/cli/init.go
+++ b/restic/cli/init.go
@@ -6,7 +6,7 @@ import (
 	"io"
 	"strings"
 
-	"github.com/k8up-io/k8up/restic/logging"
+	"github.com/k8up-io/k8up/v2/restic/logging"
 )
 
 // Init initialises a repository, checks if the repositor exists and will

--- a/restic/cli/prune.go
+++ b/restic/cli/prune.go
@@ -3,8 +3,8 @@ package cli
 import (
 	"fmt"
 
-	"github.com/k8up-io/k8up/restic/cfg"
-	"github.com/k8up-io/k8up/restic/logging"
+	"github.com/k8up-io/k8up/v2/restic/cfg"
+	"github.com/k8up-io/k8up/v2/restic/logging"
 )
 
 // Prune will enforce the retention policy onto the repository

--- a/restic/cli/restic.go
+++ b/restic/cli/restic.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/go-logr/logr"
 
-	"github.com/k8up-io/k8up/restic/cfg"
+	"github.com/k8up-io/k8up/v2/restic/cfg"
 )
 
 type ArrayOpts []string

--- a/restic/cli/restore.go
+++ b/restic/cli/restore.go
@@ -16,10 +16,10 @@ import (
 
 	"github.com/go-logr/logr"
 
-	"github.com/k8up-io/k8up/common"
-	"github.com/k8up-io/k8up/restic/cfg"
-	"github.com/k8up-io/k8up/restic/logging"
-	"github.com/k8up-io/k8up/restic/s3"
+	"github.com/k8up-io/k8up/v2/common"
+	"github.com/k8up-io/k8up/v2/restic/cfg"
+	"github.com/k8up-io/k8up/v2/restic/logging"
+	"github.com/k8up-io/k8up/v2/restic/s3"
 )
 
 const (

--- a/restic/cli/snapshots.go
+++ b/restic/cli/snapshots.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"time"
 
-	"github.com/k8up-io/k8up/restic/logging"
+	"github.com/k8up-io/k8up/v2/restic/logging"
 )
 
 // Snapshot models a restic a single snapshot from the

--- a/restic/cli/stats.go
+++ b/restic/cli/stats.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 
-	"github.com/k8up-io/k8up/restic/cfg"
-	"github.com/k8up-io/k8up/restic/logging"
+	"github.com/k8up-io/k8up/v2/restic/cfg"
+	"github.com/k8up-io/k8up/v2/restic/logging"
 )
 
 const (

--- a/restic/cli/stdinbackup.go
+++ b/restic/cli/stdinbackup.go
@@ -3,9 +3,9 @@ package cli
 import (
 	"fmt"
 
-	"github.com/k8up-io/k8up/restic/cfg"
-	"github.com/k8up-io/k8up/restic/kubernetes"
-	"github.com/k8up-io/k8up/restic/logging"
+	"github.com/k8up-io/k8up/v2/restic/cfg"
+	"github.com/k8up-io/k8up/v2/restic/kubernetes"
+	"github.com/k8up-io/k8up/v2/restic/logging"
 )
 
 // StdinBackup create a snapshot with the data contained in the given reader.

--- a/restic/cli/unlock.go
+++ b/restic/cli/unlock.go
@@ -1,7 +1,7 @@
 package cli
 
 import (
-	"github.com/k8up-io/k8up/restic/logging"
+	"github.com/k8up-io/k8up/v2/restic/logging"
 )
 
 // Unlock will remove stale locks from the repository

--- a/restic/cli/wait.go
+++ b/restic/cli/wait.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/go-logr/logr"
 
-	"github.com/k8up-io/k8up/restic/logging"
+	"github.com/k8up-io/k8up/v2/restic/logging"
 )
 
 type Lock struct {

--- a/restic/kubernetes/config.go
+++ b/restic/kubernetes/config.go
@@ -7,7 +7,7 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 
-	"github.com/k8up-io/k8up/restic/cfg"
+	"github.com/k8up-io/k8up/v2/restic/cfg"
 )
 
 func getClientConfig() (*rest.Config, error) {

--- a/restic/kubernetes/pod_exec.go
+++ b/restic/kubernetes/pod_exec.go
@@ -12,7 +12,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/remotecommand"
 
-	"github.com/k8up-io/k8up/restic/logging"
+	"github.com/k8up-io/k8up/v2/restic/logging"
 )
 
 type ExecData struct {

--- a/restic/stats/handler.go
+++ b/restic/stats/handler.go
@@ -10,7 +10,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/push"
 
-	"github.com/k8up-io/k8up/restic/cli"
+	"github.com/k8up-io/k8up/v2/restic/cli"
 )
 
 const (


### PR DESCRIPTION
## Summary

ℹ️ NOTE
This is only a breaking change for users that import K8up's Go module for programming!
For Kubernetes users nothing changes.

---

This change is required when trying to use K8up's Go API from another project.
See https://golang.cafe/blog/how-to-upgrade-to-a-major-version-in-go.html.

For this reason we marked the PR as "breaking change" in v2 without bumping the tag to v3.

## Reasoning

When trying to import K8up's module using Go we get:
```bash
$ go get github.com/k8up-io/k8up
go: downloading github.com/k8up-io/k8up v1.99.99
go: github.com/k8up-io/k8up@v1.99.99: parsing go.mod:
	module declares its path as: github.com/vshn/k8up
	        but was required as: github.com/k8up-io/k8up
```
When trying using the latest v2 patch:
```
$ go get github.com/k8up-io/k8up@v2.2.1
go: errors parsing go.mod:
.../go.mod:14:2: require github.com/k8up-io/k8up: version "v2.2.1" invalid: should be v0 or v1, not v2
```

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`,
      as they show up in the changelog
- [x] Update the documentation
- [x] Update tests.
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
