### PR TITLE
Fix PreBackupPod backupCommand in the documentation

### DIFF
--- a/docs/modules/ROOT/pages/how-tos/prebackuppod.adoc
+++ b/docs/modules/ROOT/pages/how-tos/prebackuppod.adoc
@@ -19,7 +19,7 @@ kind: PreBackupPod
 metadata:
   name: mysqldump
 spec:
-  backupCommand: mysqldump -u$USER -p$PW -h $DB_HOST --all-databases
+  backupCommand: sh -c 'mysqldump -u$USER -p$PW -h $DB_HOST --all-databases'
   pod:
     spec:
       containers:


### PR DESCRIPTION
## Summary

Edits [https://k8up.io/k8up/2.3/how-tos/prebackuppod.html](https://k8up.io/k8up/2.3/how-tos/prebackuppod.html) to make the PreBackupPod example work. The previous command does not work, since without a shell the environment variables are not interpolated.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`,
      as they show up in the changelog
- [x] Update the documentation.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
