### PR TITLE
Replace Helm installation instructions with link

### DIFF
--- a/docs/modules/ROOT/pages/how-tos/installation.adoc
+++ b/docs/modules/ROOT/pages/how-tos/installation.adoc
@@ -4,21 +4,7 @@
 
 The most convenient way to install K8up is using https://helm.sh/[helm].
 
-. Add the `appuio` repository:
-+
-[source,bash]
-----
-helm repo add appuio https://charts.appuio.ch
-helm repo update
-----
-
-. Install K8up:
-+
-[source,bash]
-----
-kubectl create namespace k8up-operator
-helm install k8up appuio/k8up --namespace k8up-operator
-----
+Please refer to the installation instructions in the https://github.com/appuio/charts/tree/master/appuio/k8up[Helm chart].
 
 == Kustomize
 


### PR DESCRIPTION
## Summary

As discussed in https://github.com/appuio/charts/issues/419, the installation instructions are outdated.
Replace it with a link for the time being, until the chart repo moved and Kustomize support is removed in #649

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`,
      as they show up in the changelog
- [x] Update the documentation.
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
