### PR TITLE
Fix nil pointer panic in Archive spec

### DIFF
--- a/controllers/archive_controller.go
+++ b/controllers/archive_controller.go
@@ -49,6 +49,9 @@ func (r *ArchiveReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	if archive.Spec.Backend != nil {
 		repository = archive.Spec.Backend.String()
 	}
+	if archive.Spec.RestoreSpec == nil {
+		archive.Spec.RestoreSpec = &k8upv1.RestoreSpec{}
+	}
 	config := job.NewConfig(ctx, r.Client, log, archive, r.Scheme, repository)
 
 	archiveHandler := handler.NewHandler(config)

--- a/controllers/schedule_controller.go
+++ b/controllers/schedule_controller.go
@@ -55,6 +55,9 @@ func (r *ScheduleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	if schedule.Spec.Backend != nil {
 		repository = schedule.Spec.Backend.String()
 	}
+	if schedule.Spec.Archive != nil && schedule.Spec.Archive.RestoreSpec == nil {
+		schedule.Spec.Archive.RestoreSpec = &k8upv1.RestoreSpec{}
+	}
 	config := job.NewConfig(ctx, r.Client, log, schedule, r.Scheme, repository)
 
 	return ctrl.Result{}, handler.NewScheduleHandler(config, schedule, effectiveSchedules).Handle()


### PR DESCRIPTION
## Summary

In the Archive CR, if `spec.restore` is not given, it results in panics when trying to reconcile Archives or Schedules.
This fixes it by defining an empty Restore spec.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`,
      as they show up in the changelog
- [x] Update the documentation.
- [x] Update tests.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
