### PR TITLE
change to array of str for acceptable errors on repo init

### DIFF
--- a/restic/cli/init.go
+++ b/restic/cli/init.go
@@ -46,14 +46,16 @@ func (i *initStdErrWrapper) Write(p []byte) (n int, err error) {
 	scanner := bufio.NewScanner(bytes.NewReader(p))
 
 	// array of acceptable errors to attempt to continue
-	okErrorArray := []string{"already initialized", "config already exists"}
-	for _, errorString := range okErrorArray {
-		for scanner.Scan() {
+	okErrorArray := []string{"already initialized", "already exists"}
+
+	for scanner.Scan() {
+		for _, errorString := range okErrorArray {
 			if strings.Contains(scanner.Text(), errorString) {
 				i.exists = true
 				return len(p), nil
 			}
 		}
 	}
+
 	return i.Writer.Write(p)
 }

--- a/restic/cli/init.go
+++ b/restic/cli/init.go
@@ -45,15 +45,15 @@ type initStdErrWrapper struct {
 func (i *initStdErrWrapper) Write(p []byte) (n int, err error) {
 	scanner := bufio.NewScanner(bytes.NewReader(p))
 
-    // array of acceptable errors to attempt to continue
-    okErrorArray := []string{"already initialized", "config already exists"}
-    for _, errorString := range okErrorArray {
-    	for scanner.Scan() {
-    		if strings.Contains(scanner.Text(), errorString) {
-    			i.exists = true
-    			return len(p), nil
-    		}
-        }
-    }
+	// array of acceptable errors to attempt to continue
+	okErrorArray := []string{"already initialized", "config already exists"}
+	for _, errorString := range okErrorArray {
+		for scanner.Scan() {
+			if strings.Contains(scanner.Text(), errorString) {
+				i.exists = true
+				return len(p), nil
+			}
+		}
+	}
 	return i.Writer.Write(p)
 }

--- a/restic/cli/init.go
+++ b/restic/cli/init.go
@@ -45,11 +45,15 @@ type initStdErrWrapper struct {
 func (i *initStdErrWrapper) Write(p []byte) (n int, err error) {
 	scanner := bufio.NewScanner(bytes.NewReader(p))
 
-	for scanner.Scan() {
-		if strings.Contains(scanner.Text(), "already initialized") {
-			i.exists = true
-			return len(p), nil
-		}
-	}
+    // array of acceptable errors to attempt to continue
+    okErrorArray := []string{"already initialized", "config already exists"}
+    for _, errorString := range okErrorArray {
+    	for scanner.Scan() {
+    		if strings.Contains(scanner.Text(), errorString) {
+    			i.exists = true
+    			return len(p), nil
+    		}
+        }
+    }
 	return i.Writer.Write(p)
 }


### PR DESCRIPTION
## Summary
This is to fix this issue: https://github.com/k8up-io/k8up/issues/690

We currently only check for "already intitialized", but in the restic backend for backblaze b2, they also throw "config already exists" as a possible error for the same thing. Because both errors are possible and probably fine, I created an array, in case more show up in the future, for easier fixing.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [ ] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`,
      as they show up in the changelog
- [ ] Update the documentation.
- [ ] Update tests.
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
