### PR TITLE
Add '--host' parameter to 'restic forget' call in Prune jobs

### DIFF
--- a/docs/modules/ROOT/pages/references/object-specifications.adoc
+++ b/docs/modules/ROOT/pages/references/object-specifications.adoc
@@ -326,6 +326,8 @@ List of available settings:
 
 WARNING: Please don't confuse `tags` and `keepTags` here. If you specify `keepTags` it will remove all snapshots that don't have the tag! If you use the `tags` array it will apply the retention only to snapshots with that specific tag. That way there can be multiple backup sets on a repository, for example `prod` and `dev`.
 
+NOTE: The retention is applied per namespace.
+
 == Backend
 
 [source,yaml]

--- a/restic/cli/prune.go
+++ b/restic/cli/prune.go
@@ -45,6 +45,9 @@ func (r *Restic) Prune(tags ArrayOpts) error {
 	if cfg.Config.PruneKeepTags {
 		args = append(args, "--keep-tag")
 	}
+	if cfg.Config.Hostname != "" {
+		args = append(args, "--host="+cfg.Config.Hostname)
+	}
 
 	resticPruneLogger := prunelogger.WithName("restic")
 	opts := CommandOptions{


### PR DESCRIPTION
## Summary

The `restic backup` subcommand is using the `--host` parameter, but not when pruning.
This PR adds `--host` to the `restic forget` subcommand to make it more consistent.

See also https://restic.readthedocs.io/en/v0.13.1/060_forget.html#removing-snapshots-according-to-a-policy
> Additionally, you can restrict the policy to only process snapshots which have a particular hostname with the --host parameter, or tags with the --tag option.

Fixes #686 

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`,
      as they show up in the changelog
- [ ] Update the documentation.
- [ ] Update tests.
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
