### PR TITLE
Regression: Add missing RBAC rule for events

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -20,7 +20,7 @@
   `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
   as they show up in the changelog
 - [ ] PR contains the label `area:chart`
-- [ ] PR contains the chart label, e.g. `chart:appcat-service-s3`
+- [ ] PR contains the chart label, e.g. `chart:k8up`
 - [ ] Variables are documented in the values.yaml using the format required by [Helm-Docs](https://github.com/norwoodj/helm-docs#valuesyaml-metadata).
 - [ ] Chart Version bumped if immediate release after merging is planned
 - [ ] I have run `make chart-docs`

--- a/api/v1/groupversion_info.go
+++ b/api/v1/groupversion_info.go
@@ -2,8 +2,6 @@
 // +kubebuilder:object:generate=true
 // +groupName=k8up.io
 
-// +kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=get;list;create;update
-
 package v1
 
 import (

--- a/charts/k8up/Chart.yaml
+++ b/charts/k8up/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
   - backup
   - operator
   - restic
-version: 3.0.0
+version: 3.0.1
 sources:
   - https://github.com/k8up-io/k8up
 maintainers:

--- a/charts/k8up/README.md
+++ b/charts/k8up/README.md
@@ -1,6 +1,6 @@
 # k8up
 
-![Version: 3.0.0](https://img.shields.io/badge/Version-3.0.0-informational?style=flat-square)
+![Version: 3.0.1](https://img.shields.io/badge/Version-3.0.1-informational?style=flat-square)
 
 Kubernetes and OpenShift Backup Operator based on restic
 
@@ -13,7 +13,7 @@ helm repo add k8up-io https://k8up-io.github.io/k8up
 helm install k8up k8up-io/k8up
 ```
 ```bash
-kubectl apply -f https://github.com/k8up-io/k8up/releases/download/k8up-3.0.0/k8up-crd.yaml
+kubectl apply -f https://github.com/k8up-io/k8up/releases/download/k8up-3.0.1/k8up-crd.yaml
 ```
 
 <!---

--- a/charts/k8up/templates/operator-clusterrole.yaml
+++ b/charts/k8up/templates/operator-clusterrole.yaml
@@ -52,6 +52,13 @@ rules:
   - apiGroups:
       - ""
     resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - ""
+    resources:
       - persistentvolumeclaims
     verbs:
       - get

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -50,6 +50,13 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
   - persistentvolumeclaims
   verbs:
   - get

--- a/controllers/controller_setup.go
+++ b/controllers/controller_setup.go
@@ -5,6 +5,9 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
+// +kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=get;list;create;update
+// +kubebuilder:rbac:groups=core,resources=events,verbs=create;patch
+
 // ReconcilerSetup is a common interface to configure reconcilers.
 type ReconcilerSetup interface {
 	SetupWithManager(mgr ctrl.Manager, l logr.Logger) error

--- a/docs/modules/ROOT/pages/explanations/release.adoc
+++ b/docs/modules/ROOT/pages/explanations/release.adoc
@@ -55,7 +55,7 @@ This process mostly relies on https://goreleaser.com/[GoReleaser].
 
 == Helm Chart Release
 
-Releasing a new version of a Helm chart requires pushing a **new Git tag**, following the SemVer schema with a **chart name prefix**, for example `appcat-service-s3-1.2.3`.
+Releasing a new version of a Helm chart requires pushing a **new Git tag**, following the SemVer schema with a **chart name prefix**, for example `k8up-3.2.1`.
 It's recommended to create a PR for each Helm chart change separately.
 After merging a PR for a Helm chart it's _not_ required to immediately release it.
 


### PR DESCRIPTION
## Summary

Apparently, with the chart move from APPUiO to this repo, the RBAC rules for the controller to create events got forgotten.
This PR re-adds this.

Contains some other small typo fixes

## Checklist

### For Helm Chart changes

- [x] Categorize the PR by setting a good title and adding one of the labels:
  `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
  as they show up in the changelog
- [x] PR contains the label `area:chart`
- [x] PR contains the chart label, e.g. `chart:appcat-service-s3`
- [x] Variables are documented in the values.yaml using the format required by [Helm-Docs](https://github.com/norwoodj/helm-docs#valuesyaml-metadata).
- [x] Chart Version bumped if immediate release after merging is planned
- [x] I have run `make chart-docs`
- [x] Link this PR to related code release or other issues.

<!--
NOTE:
Do *not* mix code changes with chart changes, it will break the release process.
Delete the checklist section that doesn't apply to the change.

NOTE:
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
