### PR TITLE
Document K8upJobStuck alerts

### DIFF
--- a/charts/k8up/Chart.yaml
+++ b/charts/k8up/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
   - backup
   - operator
   - restic
-version: 3.0.1
+version: 3.0.2
 sources:
   - https://github.com/k8up-io/k8up
 maintainers:

--- a/charts/k8up/README.md
+++ b/charts/k8up/README.md
@@ -1,6 +1,6 @@
 # k8up
 
-![Version: 3.0.1](https://img.shields.io/badge/Version-3.0.1-informational?style=flat-square)
+![Version: 3.0.2](https://img.shields.io/badge/Version-3.0.2-informational?style=flat-square)
 
 Kubernetes and OpenShift Backup Operator based on restic
 
@@ -13,7 +13,7 @@ helm repo add k8up-io https://k8up-io.github.io/k8up
 helm install k8up k8up-io/k8up
 ```
 ```bash
-kubectl apply -f https://github.com/k8up-io/k8up/releases/download/k8up-3.0.1/k8up-crd.yaml
+kubectl apply -f https://github.com/k8up-io/k8up/releases/download/k8up-3.0.2/k8up-crd.yaml
 ```
 
 <!---

--- a/charts/k8up/templates/prometheus/prometheusrule.yaml
+++ b/charts/k8up/templates/prometheus/prometheusrule.yaml
@@ -22,6 +22,7 @@ spec:
           annotations:
             summary: Amount of errors of last restic backup
             description: This alert is fired when error number is > 0
+            runbook_url: https://k8up.io/k8up/explanations/runbooks/K8upResticErrors.html
         - alert: K8upBackupNotRunning
           expr: sum(rate(k8up_jobs_total[25h])) == 0 and on(namespace) k8up_schedules_gauge > 0
           for: 1m
@@ -29,6 +30,7 @@ spec:
             severity: critical
           annotations:
             summary: "No K8up jobs were run in {{ "{{ $labels.namespace }}" }} within the last 24 hours. Check the operator, there might be a deadlock"
+            runbook_url: https://k8up.io/k8up/explanations/runbooks/K8upBackupNotRunning.html
         - alert: K8upJobStuck
           expr: k8up_jobs_queued_gauge{jobType="backup"} > 0 and on(namespace) k8up_schedules_gauge > 0
           for: 24h
@@ -36,6 +38,7 @@ spec:
             severity: critical
           annotations:
             summary: "K8up jobs are stuck in {{ "{{ $labels.namespace }}" }} for the last 24 hours."
+            runbook_url: https://k8up.io/k8up/explanations/runbooks/K8upJobStuck.html
         {{- range .Values.metrics.prometheusRule.jobFailedRulesFor }}
         - alert: K8up{{- . | title -}}Failed
           expr: (sum(kube_job_status_failed) by(job_name, namespace) * on(job_name, namespace) group_right() kube_job_labels{label_k8up_syn_tools_type="{{- . -}}"}) > 0
@@ -44,6 +47,7 @@ spec:
             severity: critical
           annotations:
             summary: "Job in {{ "{{ $labels.namespace }}" }} of type {{ "{{ $labels.label_k8up_syn_tools_type }}" }} failed"
+            runbook_url: https://k8up.io/k8up/explanations/runbooks/K8up{{- . | title -}}Failed.html
         {{- end }}
         {{- end }}
         {{- with .Values.metrics.prometheusRule.additionalRules }}

--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -29,6 +29,8 @@
 * xref:references/status.adoc[Status and Conditions]
 
 .Explanation
+* Runbooks
+** xref:explanations/runbooks/K8upJobStuck.adoc[K8upJobStuck]
 * xref:explanations/backup.adoc[Backup Methods]
 * xref:explanations/architecture.adoc[Architecture]
 * xref:explanations/ide.adoc[IDE Integration]

--- a/docs/modules/ROOT/pages/explanations/runbooks/K8upJobStuck.adoc
+++ b/docs/modules/ROOT/pages/explanations/runbooks/K8upJobStuck.adoc
@@ -1,0 +1,17 @@
+= Runbook: K8upJobStuck
+
+A K8up job (backup, check, prune) has been queued without starting for a long time
+
+== Why is this relevant?
+
+If a `backup` cannot be started, no backup will take place.
+
+== Troubleshooting
+
+In the namespace that is mentioned in the `message` annotation (NOT the one mentioned in the `namespace` label):
+
+* Check for `jobs` that could not be started/run
+* Check `backup`, `check` or `prune` objects (`kubectl get backup,check,prune`)
+
+The alert will persist, even if subsequent jobs succeed.
+If subsequent jobs of the same type were successful, delete the problematic object to resolve the monitoring alert.


### PR DESCRIPTION
## Summary

* Add a run book for the `K8upJobStuck` alert

## Checklist

### For Helm Chart changes

- [x] Categorize the PR by setting a good title and adding one of the labels:
  `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
  as they show up in the changelog
- [x] PR contains the label `area:chart`
- [x] PR contains the chart label, e.g. `chart:k8up`
- [x] Variables are documented in the values.yaml using the format required by [Helm-Docs](https://github.com/norwoodj/helm-docs#valuesyaml-metadata).
- [x] Chart Version bumped if immediate release after merging is planned
- [x] I have run `make chart-docs`
- [x] Link this PR to related code release or other issues.