### PR TITLE
Add step required to clear K8upJobStuck

### DIFF
--- a/docs/modules/ROOT/pages/explanations/runbooks/K8upJobStuck.adoc
+++ b/docs/modules/ROOT/pages/explanations/runbooks/K8upJobStuck.adoc
@@ -14,4 +14,4 @@ In the namespace that is mentioned in the `message` annotation (NOT the one ment
 * Check `backup`, `check` or `prune` objects (`kubectl get backup,check,prune`)
 
 The alert will persist, even if subsequent jobs succeed.
-If subsequent jobs of the same type were successful, delete the problematic object to resolve the monitoring alert.
+If subsequent jobs of the same type were successful, delete the problematic object and kill the k8up operator process (or delete the k8up pod) to resolve the monitoring alert.


### PR DESCRIPTION
Mention that restarting the k8up operator process is necessary to clear K8upJobStuck

## Summary

* The K8upJobStuck alert does not clear on its own even when the stuck jobs have been removed
* Killing the operator process or deleting the pod will clear the counters and the alert
* Thus, mention this in the documentation

## Checklist

### For Code changes

- [x] Categorize the PR by setting a good title and adding one of the labels:
  `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
  as they show up in the changelog
- [x] I have not made _any_ changes in the `charts/` directory.
