### PR TITLE
Restic: Improve error handling when stats dir doesn't exist

### DIFF
--- a/restic/cli/stats.go
+++ b/restic/cli/stats.go
@@ -219,7 +219,12 @@ func (p *PromMetrics) ToProm() []prometheus.Collector {
 func (r *Restic) getMountedFolders() []string {
 	files, err := os.ReadDir(cfg.Config.BackupDir)
 	if err != nil {
-		r.logger.WithName("MountCollector").Error(err, "can't list mounted folders for stats")
+		log := r.logger.WithName("MountCollector")
+		if os.IsNotExist(err) {
+			log.Info("stats mount dir doesn't exist, skipping stats", "dir", cfg.Config.BackupDir)
+		} else {
+			log.Error(err, "can't list mounted folders for stats")
+		}
 		return []string{}
 	}
 


### PR DESCRIPTION
## Summary

Fixes: #563 
There were a number of users asking about why they see an error with stacktrace doesn't seem to hurt anything.
This PR doesn't log a stack trace anymore if the mount dir doesn't exist.


## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
  `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
  as they show up in the changelog
- [x] PR contains the label `area:operator`
- [x] Link this PR to related issues
- [x] I have not made _any_ changes in the `charts/` directory.
