### PR TITLE
Pin K8up image tag in chart

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,8 +74,6 @@ deploy: kind-load-image install ## Deploy controller in the configured Kubernete
 		--set image.registry=$(E2E_REGISTRY) \
 		--set image.repository=$(E2E_REPO) \
 		--set image.tag=$(E2E_TAG) \
-		--set k8up.backupImage.repository=$(E2E_REGISTRY)/$(E2E_REPO) \
-		--set k8up.backupImage.tag=$(E2E_TAG) \
 		--wait $(deploy_args)
 
 .PHONY: generate

--- a/charts/k8up/Chart.yaml
+++ b/charts/k8up/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
   - backup
   - operator
   - restic
-version: 3.0.2
+version: 4.0.0
 sources:
   - https://github.com/k8up-io/k8up
 maintainers:

--- a/charts/k8up/README.gotmpl.md
+++ b/charts/k8up/README.gotmpl.md
@@ -66,3 +66,5 @@ The image tag is now pinned again and not using a floating tag.
 
 * Parameter changed: `image.tag` now defaults to a pinned version. Each new K8up version now requires also a new chart version.
 * Parameter changed: `image.pullPolicy` now defaults to `IfNotPresent` instead of `Always`.
+* Parameter changed: `k8up.backupImage.repository` is now unset, which defaults to the same image as defined in `image.{registry/repository}`.
+* Parameter changed: `k8up.backupImage.tag` is now unset, which defaults to the same image tag as defined in `image.tag`.

--- a/charts/k8up/README.gotmpl.md
+++ b/charts/k8up/README.gotmpl.md
@@ -23,7 +23,7 @@ Document your changes in values.yaml and let `make docs:helm` generate this sect
 -->
 {{ template "chart.valuesSection" . }}
 
-## Upgrading from Charts 0.x to 1.x
+## Upgrading from Charts v0 to v1
 
 * In `image.repository` the registry domain was moved into its own parameter `image.registry`.
 * K8up 1.x features leader election, this enables rolling updates and multiple replicas.
@@ -32,7 +32,7 @@ Document your changes in values.yaml and let `make docs:helm` generate this sect
 * Note: Deployment strategy type has changed from `Recreate` to `RollingUpdate`.
 * CRDs need to be installed separately, they are no longer included in this chart.
 
-## Upgrading from Charts 1.x to 2.x
+## Upgrading from Charts v1 to v2
 
 * Note: `image.repository` changed from `vshn/k8up` to `k8up-io/k8up`.
 * Note: `image.registry` changed from `quay.io` to `ghcr.io`.
@@ -40,7 +40,7 @@ Document your changes in values.yaml and let `make docs:helm` generate this sect
 * `metrics.prometheusRule.legacyRules` has been removed (no support for OpenShift 3.11 anymore).
 * Note: `k8up.backupImage.repository` changed from `quay.io/vshn/wrestic` to `ghcr.io/k8up-io/k8up` (`wrestic` is not needed anymore in K8up v2).
 
-## Upgrading from Charts 2.x to 3.x
+## Upgrading from Charts v2 to v3
 
 Due to the migration of the chart from [APPUiO](https://github.com/appuio/charts/tree/master/appuio/k8up) to this repo, we decided to make a breaking change for the chart.
 Only chart archives from version 3.x can be downloaded from the https://k8up-io.github.io/k8up index.
@@ -59,3 +59,10 @@ In most cases this shouldn't be an issue and Helm should be able to cleanup the 
 * Note: ClusterRoleBinding `${release-name}-leader-election-rolebinding` removed (not needed anymore).
 * Note: Renamed ClusterRole `${release-name}-k8up-view` to `${release-name}-view`.
 * Note: Renamed ClusterRole `${release-name}-k8up-edit` to `${release-name}-edit`.
+
+## Upgrading from Charts v3 to v4
+
+The image tag is now pinned again and not using a floating tag.
+
+* Parameter changed: `image.tag` now defaults to a pinned version. Each new K8up version now requires also a new chart version.
+* Parameter changed: `image.pullPolicy` now defaults to `IfNotPresent` instead of `Always`.

--- a/charts/k8up/README.md
+++ b/charts/k8up/README.md
@@ -46,8 +46,8 @@ Document your changes in values.yaml and let `make docs:helm` generate this sect
 | image.repository | string | `"k8up-io/k8up"` | Operator image repository |
 | image.tag | string | `"v2.5.2"` | Operator image tag (version) |
 | imagePullSecrets | list | `[]` |  |
-| k8up.backupImage.repository | string | `"ghcr.io/k8up-io/k8up"` | The backup runner image repository |
-| k8up.backupImage.tag | string | `"v2"` | The backup runner image tag |
+| k8up.backupImage.repository | string | `""` | The backup runner image repository. Defaults to `{image.registry}/{image.repository}`. Specify an image repository including registry, e.g. `example.com/repo/image` |
+| k8up.backupImage.tag | string | `""` | The backup runner image tag Defaults to `{image.tag}` |
 | k8up.enableLeaderElection | bool | `true` | Specifies whether leader election should be enabled. |
 | k8up.envVars | list | `[]` | envVars allows the specification of additional environment variables. See [values.yaml](values.yaml) how to specify See documentation which variables are supported. |
 | k8up.globalResources | object | empty values | Specify the resource requests and limits that the Pods should have when they are scheduled by K8up. You are still able to override those via K8up resources, but this gives cluster administrators custom defaults. |
@@ -127,6 +127,9 @@ The image tag is now pinned again and not using a floating tag.
 
 * Parameter changed: `image.tag` now defaults to a pinned version. Each new K8up version now requires also a new chart version.
 * Parameter changed: `image.pullPolicy` now defaults to `IfNotPresent` instead of `Always`.
+* Parameter changed: `k8up.backupImage.repository` is now unset, which defaults to the same image as defined in `image.{registry/repository}`.
+* Parameter changed: `k8up.backupImage.tag` is now unset, which defaults to the same image tag as defined in `image.tag`.
+
 ## Source Code
 
 * <https://github.com/k8up-io/k8up>

--- a/charts/k8up/README.md
+++ b/charts/k8up/README.md
@@ -1,6 +1,6 @@
 # k8up
 
-![Version: 3.0.2](https://img.shields.io/badge/Version-3.0.2-informational?style=flat-square)
+![Version: 4.0.0](https://img.shields.io/badge/Version-4.0.0-informational?style=flat-square)
 
 Kubernetes and OpenShift Backup Operator based on restic
 
@@ -13,7 +13,7 @@ helm repo add k8up-io https://k8up-io.github.io/k8up
 helm install k8up k8up-io/k8up
 ```
 ```bash
-kubectl apply -f https://github.com/k8up-io/k8up/releases/download/k8up-3.0.2/k8up-crd.yaml
+kubectl apply -f https://github.com/k8up-io/k8up/releases/download/k8up-4.0.0/k8up-crd.yaml
 ```
 
 <!---
@@ -41,10 +41,10 @@ Document your changes in values.yaml and let `make docs:helm` generate this sect
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` |  |
-| image.pullPolicy | string | `"Always"` | Operator image pull policy |
+| image.pullPolicy | string | `"IfNotPresent"` | Operator image pull policy |
 | image.registry | string | `"ghcr.io"` | Operator image registry |
 | image.repository | string | `"k8up-io/k8up"` | Operator image repository |
-| image.tag | string | `"v2"` | Operator image tag (version) |
+| image.tag | string | `"v2.5.2"` | Operator image tag (version) |
 | imagePullSecrets | list | `[]` |  |
 | k8up.backupImage.repository | string | `"ghcr.io/k8up-io/k8up"` | The backup runner image repository |
 | k8up.backupImage.tag | string | `"v2"` | The backup runner image tag |
@@ -84,7 +84,7 @@ Document your changes in values.yaml and let `make docs:helm` generate this sect
 | serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template |
 | tolerations | list | `[]` |  |
 
-## Upgrading from Charts 0.x to 1.x
+## Upgrading from Charts v0 to v1
 
 * In `image.repository` the registry domain was moved into its own parameter `image.registry`.
 * K8up 1.x features leader election, this enables rolling updates and multiple replicas.
@@ -93,7 +93,7 @@ Document your changes in values.yaml and let `make docs:helm` generate this sect
 * Note: Deployment strategy type has changed from `Recreate` to `RollingUpdate`.
 * CRDs need to be installed separately, they are no longer included in this chart.
 
-## Upgrading from Charts 1.x to 2.x
+## Upgrading from Charts v1 to v2
 
 * Note: `image.repository` changed from `vshn/k8up` to `k8up-io/k8up`.
 * Note: `image.registry` changed from `quay.io` to `ghcr.io`.
@@ -101,7 +101,7 @@ Document your changes in values.yaml and let `make docs:helm` generate this sect
 * `metrics.prometheusRule.legacyRules` has been removed (no support for OpenShift 3.11 anymore).
 * Note: `k8up.backupImage.repository` changed from `quay.io/vshn/wrestic` to `ghcr.io/k8up-io/k8up` (`wrestic` is not needed anymore in K8up v2).
 
-## Upgrading from Charts 2.x to 3.x
+## Upgrading from Charts v2 to v3
 
 Due to the migration of the chart from [APPUiO](https://github.com/appuio/charts/tree/master/appuio/k8up) to this repo, we decided to make a breaking change for the chart.
 Only chart archives from version 3.x can be downloaded from the https://k8up-io.github.io/k8up index.
@@ -121,6 +121,12 @@ In most cases this shouldn't be an issue and Helm should be able to cleanup the 
 * Note: Renamed ClusterRole `${release-name}-k8up-view` to `${release-name}-view`.
 * Note: Renamed ClusterRole `${release-name}-k8up-edit` to `${release-name}-edit`.
 
+## Upgrading from Charts v3 to v4
+
+The image tag is now pinned again and not using a floating tag.
+
+* Parameter changed: `image.tag` now defaults to a pinned version. Each new K8up version now requires also a new chart version.
+* Parameter changed: `image.pullPolicy` now defaults to `IfNotPresent` instead of `Always`.
 ## Source Code
 
 * <https://github.com/k8up-io/k8up>

--- a/charts/k8up/templates/_helpers.tpl
+++ b/charts/k8up/templates/_helpers.tpl
@@ -71,3 +71,12 @@ Create the name of the service account to use
     {{ default "default" .Values.serviceAccount.name }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Backup Image
+*/}}
+{{- define "k8up.backupImage" -}}
+{{- with .Values -}}
+{{ if .k8up.backupImage.repository }}{{ .k8up.backupImage.repository }}{{ else }}{{ .image.registry}}/{{ .image.repository }}{{ end }}:{{ if .k8up.backupImage.tag }}{{ .k8up.backupImage.tag }}{{ else }}{{ .image.tag }}{{ end }}
+{{- end -}}
+{{- end -}}

--- a/charts/k8up/templates/deployment.yaml
+++ b/charts/k8up/templates/deployment.yaml
@@ -30,10 +30,8 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args: [ operator ]
           env:
-          {{- with .Values.k8up.backupImage }}
             - name: BACKUP_IMAGE
-              value: "{{ .repository}}:{{ .tag }}"
-          {{- end }}
+              value: "{{ include "k8up.backupImage" . }}"
           {{- with .Values.k8up.timezone }}
             - name: TZ
               value: {{ . }}

--- a/charts/k8up/values.yaml
+++ b/charts/k8up/values.yaml
@@ -32,10 +32,13 @@ k8up:
   #       key: access-key-id
 
   backupImage:
-    # -- The backup runner image repository
-    repository: ghcr.io/k8up-io/k8up
+    # -- The backup runner image repository.
+    # Defaults to `{image.registry}/{image.repository}`.
+    # Specify an image repository including registry, e.g. `example.com/repo/image`
+    repository: ""
     # -- The backup runner image tag
-    tag: v2
+    # Defaults to `{image.tag}`
+    tag: ""
 
   # -- Specifies the timezone K8up is using for scheduling.
   # Empty value defaults to the timezone in which Kubernetes is deployed.

--- a/charts/k8up/values.yaml
+++ b/charts/k8up/values.yaml
@@ -4,13 +4,13 @@
 replicaCount: 1
 image:
   # -- Operator image pull policy
-  pullPolicy: Always
+  pullPolicy: IfNotPresent
   # -- Operator image registry
   registry: ghcr.io
   # -- Operator image repository
   repository: k8up-io/k8up
   # -- Operator image tag (version)
-  tag: v2
+  tag: v2.5.2
 
 imagePullSecrets: []
 serviceAccount:

--- a/e2e/definitions/operator/values.yaml
+++ b/e2e/definitions/operator/values.yaml
@@ -6,9 +6,6 @@ image:
   repository: $E2E_REPO
   tag: $E2E_TAG
 k8up:
-  backupImage:
-    repository: $E2E_REGISTRY/$E2E_REPO
-    tag: $E2E_TAG
   env:
     - name: K8UP_DEBUG
       value: "true"


### PR DESCRIPTION
## Summary

For Chart v3 we set the image to `v2` with `Always` pull policy. In hindsight, this was a mistake.
We now have sometimes new K8up releases that introduce new non-breaking features also in CRDs, which make an upgrade with CRDs necessary. With `Always` pull policy, there can be new K8up Pod started with old CRDs, causing issues and errors.

This change now pins the tag again.
As a Bonus, specifying `k8up.backupImage` isn't necessary anymore, it defaults to values defined in `image`.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
  `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
  as they show up in the changelog
- [x] PR contains the label `area:chart`
- [x] PR contains the chart label, e.g. `chart:k8up`
- [x] Variables are documented in the values.yaml using the format required by [Helm-Docs](https://github.com/norwoodj/helm-docs#valuesyaml-metadata).
- [x] Chart Version bumped if immediate release after merging is planned
- [x] I have run `make chart-docs`
- [x] Link this PR to related code release or other issues.

<!--
NOTE:
Do *not* mix code changes with chart changes, it will break the release process.
Delete the checklist section that doesn't apply to the change.

NOTE:
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
