### PR TITLE
Add missing watch permissions to chart

### DIFF
--- a/charts/k8up/Chart.yaml
+++ b/charts/k8up/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
   - backup
   - operator
   - restic
-version: 4.0.0
+version: 4.0.1
 sources:
   - https://github.com/k8up-io/k8up
 maintainers:

--- a/charts/k8up/README.md
+++ b/charts/k8up/README.md
@@ -1,6 +1,6 @@
 # k8up
 
-![Version: 4.0.0](https://img.shields.io/badge/Version-4.0.0-informational?style=flat-square)
+![Version: 4.0.1](https://img.shields.io/badge/Version-4.0.1-informational?style=flat-square)
 
 Kubernetes and OpenShift Backup Operator based on restic
 
@@ -13,7 +13,7 @@ helm repo add k8up-io https://k8up-io.github.io/k8up
 helm install k8up k8up-io/k8up
 ```
 ```bash
-kubectl apply -f https://github.com/k8up-io/k8up/releases/download/k8up-4.0.0/k8up-crd.yaml
+kubectl apply -f https://github.com/k8up-io/k8up/releases/download/k8up-4.0.1/k8up-crd.yaml
 ```
 
 <!---

--- a/charts/k8up/templates/operator-clusterrole.yaml
+++ b/charts/k8up/templates/operator-clusterrole.yaml
@@ -85,6 +85,7 @@ rules:
       - delete
       - get
       - list
+      - watch
   - apiGroups:
       - k8up.io
     resources:
@@ -260,4 +261,5 @@ rules:
       - delete
       - get
       - list
+      - watch
 {{- end -}}

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -83,6 +83,7 @@ rules:
   - delete
   - get
   - list
+  - watch
 - apiGroups:
   - k8up.io
   resources:
@@ -258,3 +259,4 @@ rules:
   - delete
   - get
   - list
+  - watch

--- a/operator/backupcontroller/setup.go
+++ b/operator/backupcontroller/setup.go
@@ -15,9 +15,9 @@ import (
 // +kubebuilder:rbac:groups=batch,resources=jobs,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=pods,verbs="*"
 // +kubebuilder:rbac:groups=core,resources=pods/exec,verbs="*"
-// +kubebuilder:rbac:groups=core,resources=serviceaccounts,verbs=get;list;create;delete
+// +kubebuilder:rbac:groups=core,resources=serviceaccounts,verbs=get;list;watch;create;delete
 // +kubebuilder:rbac:groups=core,resources=persistentvolumeclaims,verbs=get;list;watch
-// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles;rolebindings,verbs=get;list;create;delete
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles;rolebindings,verbs=get;list;watch;create;delete
 
 // SetupWithManager configures the reconciler.
 func (r *BackupReconciler) SetupWithManager(mgr controllerruntime.Manager, _ logr.Logger) error {


### PR DESCRIPTION
## Summary

Adds the missing watch permissions for service accounts, roles and role bindings.
This is required for future code refactorings with object caching.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
  `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
  as they show up in the changelog
- [x] PR contains the label `area:chart`
- [x] PR contains the chart label, e.g. `chart:k8up`
- [x] Variables are documented in the values.yaml using the format required by [Helm-Docs](https://github.com/norwoodj/helm-docs#valuesyaml-metadata).
- [x] Chart Version bumped if immediate release after merging is planned
- [x] I have run `make chart-docs`
- [x] Link this PR to related code release or other issues.
