### PR TITLE
Remove K8upJobStuck alert

### DIFF
--- a/charts/k8up/Chart.yaml
+++ b/charts/k8up/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
   - backup
   - operator
   - restic
-version: 4.0.1
+version: 4.0.2
 sources:
   - https://github.com/k8up-io/k8up
 maintainers:

--- a/charts/k8up/README.md
+++ b/charts/k8up/README.md
@@ -1,6 +1,6 @@
 # k8up
 
-![Version: 4.0.1](https://img.shields.io/badge/Version-4.0.1-informational?style=flat-square)
+![Version: 4.0.2](https://img.shields.io/badge/Version-4.0.2-informational?style=flat-square)
 
 Kubernetes and OpenShift Backup Operator based on restic
 
@@ -13,7 +13,7 @@ helm repo add k8up-io https://k8up-io.github.io/k8up
 helm install k8up k8up-io/k8up
 ```
 ```bash
-kubectl apply -f https://github.com/k8up-io/k8up/releases/download/k8up-4.0.1/k8up-crd.yaml
+kubectl apply -f https://github.com/k8up-io/k8up/releases/download/k8up-4.0.2/k8up-crd.yaml
 ```
 
 <!---

--- a/charts/k8up/templates/prometheus/prometheusrule.yaml
+++ b/charts/k8up/templates/prometheus/prometheusrule.yaml
@@ -31,14 +31,6 @@ spec:
           annotations:
             summary: "No K8up jobs were run in {{ "{{ $labels.namespace }}" }} within the last 24 hours. Check the operator, there might be a deadlock"
             runbook_url: https://k8up.io/k8up/explanations/runbooks/K8upBackupNotRunning.html
-        - alert: K8upJobStuck
-          expr: k8up_jobs_queued_gauge{jobType="backup"} > 0 and on(namespace) k8up_schedules_gauge > 0
-          for: 24h
-          labels:
-            severity: critical
-          annotations:
-            summary: "K8up jobs are stuck in {{ "{{ $labels.namespace }}" }} for the last 24 hours."
-            runbook_url: https://k8up.io/k8up/explanations/runbooks/K8upJobStuck.html
         {{- range .Values.metrics.prometheusRule.jobFailedRulesFor }}
         - alert: K8up{{- . | title -}}Failed
           expr: (sum(kube_job_status_failed) by(job_name, namespace) * on(job_name, namespace) group_right() kube_job_labels{label_k8up_syn_tools_type="{{- . -}}"}) > 0

--- a/config/samples/prometheus/rules.yaml
+++ b/config/samples/prometheus/rules.yaml
@@ -23,10 +23,3 @@ groups:
       severity: critical
     annotations:
       summary: "No K8up jobs were run in {{ $labels.namespace }} within the last 24 hours. Check the operator, there might be a deadlock"
-  - alert: K8upJobStuck
-    expr: k8up_jobs_queued_gauge{jobType="backup"} > 0 and on(namespace) k8up_schedules_gauge > 0
-    for: 24h
-    labels:
-      severity: critical
-    annotations:
-      summary: "K8up jobs are stuck in {{ $labels.namespace }} for the last 24 hours."


### PR DESCRIPTION
## Summary

* With the removal of the observer in #791 (part of #743 ) this metric doesn't exist anymore.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
  `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
  as they show up in the changelog
- [x] PR contains the label `area:chart`
- [x] PR contains the chart label, e.g. `chart:k8up`
- [x] Variables are documented in the values.yaml using the format required by [Helm-Docs](https://github.com/norwoodj/helm-docs#valuesyaml-metadata).
- [x] ~Chart Version bumped if immediate release after merging is planned~ Will not release after merging without K8up release.
- [x] I have run `make chart-docs`
- [x] Link this PR to related code release or other issues.

<!--
NOTE:
Do *not* mix code changes with chart changes, it will break the release process.
Delete the checklist section that doesn't apply to the change.

NOTE:
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
