### PR TITLE
fix: exclude non-running pods from podlist

### DIFF
--- a/operator/backupcontroller/executor.go
+++ b/operator/backupcontroller/executor.go
@@ -13,6 +13,7 @@ import (
 	"github.com/k8up-io/k8up/v2/operator/job"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -60,7 +61,8 @@ func (b *BackupExecutor) listAndFilterPVCs(ctx context.Context, annotation strin
 
 	pods := &corev1.PodList{}
 	pvcPodMap := make(map[string]corev1.Pod)
-	if err := b.Config.Client.List(ctx, pods, client.InNamespace(b.backup.Namespace)); err != nil {
+	labelselector, _ := labels.Parse("!" + job.K8uplabel)
+	if err := b.Config.Client.List(ctx, pods, client.InNamespace(b.backup.Namespace), client.MatchingLabelsSelector{Selector: labelselector}); err != nil {
 		return nil, fmt.Errorf("list pods: %w", err)
 	}
 	for _, pod := range pods.Items {


### PR DESCRIPTION


## Summary

previously the executor would happily set `TARGET_PODS` for the backup job to the pod of a previous running backup instead of a actually running pod.
This prevents `k8up.io/backupcommand` from working, as then the backup job would actually check the old incarnation of itself instead of the real target pod.

## Checklist

### For Code changes

- [x] Categorize the PR by setting a good title and adding one of the labels:
  `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
  as they show up in the changelog
- [x] PR contains the label `area:operator`
- [X] Link this PR to related issues
- [X] I have not made _any_ changes in the `charts/` directory.
