### PR TITLE
Ensure there is a job for PreBackupPods if they exist.

### DIFF
--- a/cmd/restic/main.go
+++ b/cmd/restic/main.go
@@ -248,7 +248,11 @@ func backupAnnotatedPods(ctx context.Context, resticCLI *resticCli.Restic, mainL
 		return nil
 	}
 
-	podLister := kubernetes.NewPodLister(ctx, cfg.Config.BackupCommandAnnotation, cfg.Config.BackupFileExtensionAnnotation, cfg.Config.BackupContainerAnnotation, cfg.Config.Hostname, cfg.Config.TargetPods, cfg.Config.SkipPreBackup, mainLogger)
+	k8cli, err := kubernetes.NewTypedClient()
+	if err != nil {
+		return fmt.Errorf("Could not create kubernetes client: %w", err)
+	}
+	podLister := kubernetes.NewPodLister(ctx, k8cli, cfg.Config.BackupCommandAnnotation, cfg.Config.BackupFileExtensionAnnotation, cfg.Config.BackupContainerAnnotation, cfg.Config.Hostname, cfg.Config.TargetPods, cfg.Config.SkipPreBackup, mainLogger)
 	podList, err := podLister.ListPods()
 	if err != nil {
 		mainLogger.Error(err, "could not list pods", "namespace", cfg.Config.Hostname)

--- a/cmd/restic/main.go
+++ b/cmd/restic/main.go
@@ -47,6 +47,7 @@ var (
 			&cli.StringFlag{Destination: &cfg.Config.BackupCommandAnnotation, Name: "backupCommandAnnotation", EnvVars: []string{"BACKUPCOMMAND_ANNOTATION"}, Usage: "Defines the command to invoke when doing a backup via STDOUT."},
 			&cli.StringFlag{Destination: &cfg.Config.BackupFileExtensionAnnotation, Name: "fileExtensionAnnotation", EnvVars: []string{"FILEEXTENSION_ANNOTATION"}, Usage: "Defines the file extension to use for STDOUT backups."},
 			&cli.StringFlag{Destination: &cfg.Config.BackupContainerAnnotation, Name: "backucontainerannotation", EnvVars: []string{"BACKUP_CONTAINERANNOTATION"}, Value: "k8up.io/backupcommand-container", Usage: "set the annotation name that specify the backup container inside the Pod"},
+			&cli.BoolFlag{Destination: &cfg.Config.SkipPreBackup, Name: "skipPreBackup", EnvVars: []string{"SKIP_PREBACKUP"}, Usage: "If the job should skip the backup command and only backup volumes."},
 
 			&cli.StringFlag{Destination: &cfg.Config.PromURL, Name: "promURL", EnvVars: []string{"PROM_URL"}, Usage: "Sets the URL of a prometheus push gateway to report metrics."},
 			&cli.StringFlag{Destination: &cfg.Config.WebhookURL, Name: "webhookURL", Aliases: []string{"statsURL"}, EnvVars: []string{"STATS_URL"}, Usage: "Sets the URL of a server which will retrieve a webhook after the action completes."},
@@ -247,7 +248,7 @@ func backupAnnotatedPods(ctx context.Context, resticCLI *resticCli.Restic, mainL
 		return nil
 	}
 
-	podLister := kubernetes.NewPodLister(ctx, cfg.Config.BackupCommandAnnotation, cfg.Config.BackupFileExtensionAnnotation, cfg.Config.BackupContainerAnnotation, cfg.Config.Hostname, cfg.Config.TargetPods, mainLogger)
+	podLister := kubernetes.NewPodLister(ctx, cfg.Config.BackupCommandAnnotation, cfg.Config.BackupFileExtensionAnnotation, cfg.Config.BackupContainerAnnotation, cfg.Config.Hostname, cfg.Config.TargetPods, cfg.Config.SkipPreBackup, mainLogger)
 	podList, err := podLister.ListPods()
 	if err != nil {
 		mainLogger.Error(err, "could not list pods", "namespace", cfg.Config.Hostname)

--- a/docs/modules/ROOT/examples/usage/restic.txt
+++ b/docs/modules/ROOT/examples/usage/restic.txt
@@ -19,6 +19,7 @@ OPTIONS:
    --backupCommandAnnotation value            Defines the command to invoke when doing a backup via STDOUT. [$BACKUPCOMMAND_ANNOTATION]
    --fileExtensionAnnotation value            Defines the file extension to use for STDOUT backups. [$FILEEXTENSION_ANNOTATION]
    --backucontainerannotation value           set the annotation name that specify the backup container inside the Pod (default: "k8up.io/backupcommand-container") [$BACKUP_CONTAINERANNOTATION]
+   --skipPreBackup                            If the job should skip the backup command and only backup volumes. (default: false) [$SKIP_PREBACKUP]
    --promURL value                            Sets the URL of a prometheus push gateway to report metrics. [$PROM_URL]
    --webhookURL value, --statsURL value       Sets the URL of a server which will retrieve a webhook after the action completes. [$STATS_URL]
    --backupDir value                          Set from which directory the backup should be performed. (default: "/data") [$BACKUP_DIR]

--- a/e2e/test-05-annotated-backup.bats
+++ b/e2e/test-05-annotated-backup.bats
@@ -37,7 +37,7 @@ DEBUG_DETIK="true"
 	echo -n "Number of Snapshots >= 1? "
 	jq -e 'length >= 1' <<< "${output}"          # Ensure that there was actually a backup created
 
-	run get_latest_snap
+	run get_latest_snap_by_path /data/subject-pvc
 
 	run restic dump "${output}" "/data/subject-pvc/${expected_filename}"
 

--- a/operator/backupcontroller/executor.go
+++ b/operator/backupcontroller/executor.go
@@ -25,6 +25,14 @@ type BackupExecutor struct {
 	backup *k8upv1.Backup
 }
 
+// BackupPod contains all information nessecary to execute the backupcommands.
+type BackupPod struct {
+	Command       string
+	PodName       string
+	ContainerName string
+	Namespace     string
+}
+
 // NewBackupExecutor returns a new BackupExecutor.
 func NewBackupExecutor(config job.Config) *BackupExecutor {
 	return &BackupExecutor{Generic: executor.Generic{Config: config}, backup: config.Obj.(*k8upv1.Backup)}
@@ -143,6 +151,35 @@ func (b *BackupExecutor) listAndFilterPVCs(ctx context.Context, annotation strin
 	return backupItems, nil
 }
 
+// listBackupPods lists all Pods in the given namespace and filters them for K8up specific usage.
+// Specifically, all pods that have the given annotation will be listed.
+func (b *BackupExecutor) listBackupPods(ctx context.Context, annotation string) ([]BackupPod, error) {
+	log := controllerruntime.LoggerFrom(ctx)
+
+	pods := &corev1.PodList{}
+	if err := b.Config.Client.List(ctx, pods, client.InNamespace(b.backup.Namespace)); err != nil {
+		return nil, fmt.Errorf("list pods: %w", err)
+	}
+
+	foundPods := make([]BackupPod, 0)
+
+	log.Info("Listing all Pods with backup annotation", "annotation", annotation)
+
+	for _, pod := range pods.Items {
+		annotations := pod.GetAnnotations()
+		if command, ok := annotations[annotation]; ok {
+			foundPods = append(foundPods, BackupPod{
+				Command:       command,
+				PodName:       pod.Name,
+				ContainerName: pod.Spec.Containers[0].Name,
+				Namespace:     b.backup.Namespace,
+			})
+		}
+	}
+	return foundPods, nil
+
+}
+
 // findNode tries to find a PVs NodeAffinity for a specific hostname. If found will return that.
 // If not it will try to return the value of the k8up.io/hostname annotation on the PVC. If this is not set, will return
 // empty string.
@@ -205,11 +242,18 @@ func (b *BackupExecutor) startBackup(ctx context.Context) error {
 		return err
 	}
 
-	backupJobs["prebackup"] = jobItem{
-		job:           b.createJob("prebackup", "", nil),
-		targetPods:    make([]string, 0),
-		volumes:       make([]corev1.Volume, 0),
-		skipPreBackup: false,
+	backupPods, err := b.listBackupPods(ctx, cfg.Config.BackupCommandAnnotation)
+	if err != nil {
+		b.Generic.SetConditionFalseWithMessage(ctx, k8upv1.ConditionReady, k8upv1.ReasonRetrievalFailed, err.Error())
+		return err
+	}
+	if len(backupPods) > 0 {
+		backupJobs["prebackup"] = jobItem{
+			job:           b.createJob("prebackup", "", nil),
+			targetPods:    make([]string, 0),
+			volumes:       make([]corev1.Volume, 0),
+			skipPreBackup: false,
+		}
 	}
 
 	index := 0

--- a/operator/backupcontroller/executor.go
+++ b/operator/backupcontroller/executor.go
@@ -201,19 +201,15 @@ func (b *BackupExecutor) startBackup(ctx context.Context) error {
 		backupJobs[item.node] = j
 	}
 
-	preBackupPods, err := b.fetchPreBackupPodTemplates(ctx)
-
 	if err != nil {
 		return err
 	}
 
-	if len(preBackupPods.Items) != 0 {
-		backupJobs["prebackup"] = jobItem{
-			job:           b.createJob("prebackup", "", nil),
-			targetPods:    make([]string, 0),
-			volumes:       make([]corev1.Volume, 0),
-			skipPreBackup: false,
-		}
+	backupJobs["prebackup"] = jobItem{
+		job:           b.createJob("prebackup", "", nil),
+		targetPods:    make([]string, 0),
+		volumes:       make([]corev1.Volume, 0),
+		skipPreBackup: false,
 	}
 
 	index := 0

--- a/operator/backupcontroller/executor.go
+++ b/operator/backupcontroller/executor.go
@@ -26,14 +26,6 @@ type BackupExecutor struct {
 	backup *k8upv1.Backup
 }
 
-// BackupPod contains all information nessecary to execute the backupcommands.
-type BackupPod struct {
-	Command       string
-	PodName       string
-	ContainerName string
-	Namespace     string
-}
-
 // NewBackupExecutor returns a new BackupExecutor.
 func NewBackupExecutor(config job.Config) *BackupExecutor {
 	return &BackupExecutor{Generic: executor.Generic{Config: config}, backup: config.Obj.(*k8upv1.Backup)}

--- a/operator/backupcontroller/executor.go
+++ b/operator/backupcontroller/executor.go
@@ -215,7 +215,7 @@ func (b *BackupExecutor) startBackup(ctx context.Context) error {
 	}
 
 	log := controllerruntime.LoggerFrom(ctx)
-	podLister := kubernetes.NewPodLister(ctx, cfg.Config.BackupCommandAnnotation, "", b.backup.Namespace, nil, false, log)
+	podLister := kubernetes.NewPodLister(ctx, cfg.Config.BackupCommandAnnotation, "", "", b.backup.Namespace, nil, false, log)
 	backupPods, err := podLister.ListPods()
 	if err != nil {
 		log.Error(err, "could not list pods", "namespace", b.backup.Namespace)

--- a/operator/backupcontroller/executor.go
+++ b/operator/backupcontroller/executor.go
@@ -207,7 +207,7 @@ func (b *BackupExecutor) startBackup(ctx context.Context) error {
 	}
 
 	log := controllerruntime.LoggerFrom(ctx)
-	podLister := kubernetes.NewPodLister(ctx, cfg.Config.BackupCommandAnnotation, "", "", b.backup.Namespace, nil, false, log)
+	podLister := kubernetes.NewPodLister(ctx, b.Client, cfg.Config.BackupCommandAnnotation, "", "", b.backup.Namespace, nil, false, log)
 	backupPods, err := podLister.ListPods()
 	if err != nil {
 		log.Error(err, "could not list pods", "namespace", b.backup.Namespace)

--- a/operator/backupcontroller/executor.go
+++ b/operator/backupcontroller/executor.go
@@ -199,6 +199,20 @@ func (b *BackupExecutor) startBackup(ctx context.Context) error {
 		backupJobs[item.node] = j
 	}
 
+	preBackupPods, err := b.fetchPreBackupPodTemplates(ctx)
+
+	if err != nil {
+		return err
+	}
+
+	if len(preBackupPods.Items) != 0 {
+		backupJobs["prebackup"] = jobItem{
+			job:        b.createJob("prebackup", "", nil),
+			targetPods: make([]string, 0),
+			volumes:    make([]corev1.Volume, 0),
+		}
+	}
+
 	index := 0
 	for _, batchJob := range backupJobs {
 		_, err = controllerruntime.CreateOrUpdate(ctx, b.Generic.Config.Client, batchJob.job, func() error {

--- a/restic/cfg/config.go
+++ b/restic/cfg/config.go
@@ -33,6 +33,8 @@ type Configuration struct {
 	BackupContainerAnnotation     string
 	BackupDir                     string
 
+	SkipPreBackup bool
+
 	PromURL    string
 	WebhookURL string
 

--- a/restic/kubernetes/config.go
+++ b/restic/kubernetes/config.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -29,20 +28,7 @@ func getClientConfig() (*rest.Config, error) {
 	return config, nil
 }
 
-func newk8sClient() (*kubernetes.Clientset, error) {
-	config, err := getClientConfig()
-	if err != nil {
-		return nil, fmt.Errorf("can't load k8s config: %v", err)
-	}
-	k8sclient, err := kubernetes.NewForConfig(config)
-	if err != nil {
-		return nil, fmt.Errorf("can't create k8s client: %v", err)
-	}
-
-	return k8sclient, nil
-}
-
-func newTypedClient() (client.Client, error) {
+func NewTypedClient() (client.Client, error) {
 	scheme := runtime.NewScheme()
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 	utilruntime.Must(k8upv1.AddToScheme(scheme))

--- a/restic/kubernetes/pod_list.go
+++ b/restic/kubernetes/pod_list.go
@@ -68,6 +68,10 @@ func (p *PodLister) ListPods() ([]BackupPod, error) {
 		return nil, p.err
 	}
 
+	if p.skipPreBackup {
+		return nil, nil
+	}
+
 	pods, err := p.k8scli.CoreV1().Pods(p.namespace).List(p.ctx, metav1.ListOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("can't list pods: %v", err)
@@ -91,9 +95,6 @@ func (p *PodLister) ListPods() ([]BackupPod, error) {
 		_, ok := p.targetPods[pod.GetName()]
 		if len(p.targetPods) > 0 && !ok {
 			p.log.V(1).Info("pod not in target pod list, skipping", "pod", pod.GetName())
-			continue
-		}
-		if p.skipPreBackup {
 			continue
 		}
 

--- a/restic/kubernetes/snapshots.go
+++ b/restic/kubernetes/snapshots.go
@@ -16,7 +16,7 @@ func SyncSnapshotList(ctx context.Context, list []dto.Snapshot, namespace, repos
 	newList := filterAndConvert(list, namespace, repository)
 	oldList := &k8upv1.SnapshotList{}
 
-	kube, err := newTypedClient()
+	kube, err := NewTypedClient()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
With the refactorings done in the 2.6 release a bug was introduced that didn't create a job anymore if a PreBackupPod is defined. This commit fixes this, by creating a dedicated job for the pre-backup if a PreBackupPod has been defined.

Resolves: #822

## Summary

* Short summary of what's included in the PR
* Give special note to breaking changes: List the exact changes or provide links to documentation.

## Checklist

### For Code changes

- [x] Categorize the PR by setting a good title and adding one of the labels:
  `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
  as they show up in the changelog
- [x] PR contains the label `area:operator`
- [x] Link this PR to related issues
- [x] I have not made _any_ changes in the `charts/` directory.

### For Helm Chart changes

- [ ] Categorize the PR by setting a good title and adding one of the labels:
  `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
  as they show up in the changelog
- [ ] PR contains the label `area:chart`
- [ ] PR contains the chart label, e.g. `chart:k8up`
- [ ] Variables are documented in the values.yaml using the format required by [Helm-Docs](https://github.com/norwoodj/helm-docs#valuesyaml-metadata).
- [ ] Chart Version bumped if immediate release after merging is planned
- [ ] I have run `make chart-docs`
- [ ] Link this PR to related code release or other issues.

<!--
NOTE:
Do *not* mix code changes with chart changes, it will break the release process.
Delete the checklist section that doesn't apply to the change.

NOTE:
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
