### PR TITLE
Add requeue to all job types

### DIFF
--- a/operator/archivecontroller/controller.go
+++ b/operator/archivecontroller/controller.go
@@ -49,7 +49,7 @@ func (r *ArchiveReconciler) Provision(ctx context.Context, obj *k8upv1.Archive) 
 
 	if obj.Status.HasStarted() {
 		log.V(1).Info("archive just started, waiting")
-		return controllerruntime.Result{}, nil
+		return controllerruntime.Result{RequeueAfter: 5 * time.Second}, nil
 	}
 
 	if obj.Status.HasFinished() {

--- a/operator/checkcontroller/controller.go
+++ b/operator/checkcontroller/controller.go
@@ -48,7 +48,7 @@ func (r *CheckReconciler) Provision(ctx context.Context, obj *k8upv1.Check) (con
 
 	if obj.Status.HasStarted() {
 		log.V(1).Info("check just started, waiting")
-		return controllerruntime.Result{}, nil
+		return controllerruntime.Result{RequeueAfter: 5 * time.Second}, nil
 	}
 
 	if obj.Status.HasFinished() {

--- a/operator/prunecontroller/controller.go
+++ b/operator/prunecontroller/controller.go
@@ -46,7 +46,7 @@ func (r *PruneReconciler) Provision(ctx context.Context, obj *k8upv1.Prune) (con
 
 	if obj.Status.HasStarted() {
 		log.V(1).Info("prune just started, waiting")
-		return controllerruntime.Result{}, nil
+		return controllerruntime.Result{RequeueAfter: 5 * time.Second}, nil
 	}
 	if obj.Status.HasFinished() {
 		executor.cleanupOldPrunes(ctx, obj)

--- a/operator/restorecontroller/controller.go
+++ b/operator/restorecontroller/controller.go
@@ -46,7 +46,7 @@ func (r *RestoreReconciler) Provision(ctx context.Context, obj *k8upv1.Restore) 
 
 	if obj.Status.HasStarted() {
 		log.V(1).Info("restore just started, waiting")
-		return controllerruntime.Result{}, nil
+		return controllerruntime.Result{RequeueAfter: 5 * time.Second}, nil
 	}
 
 	if obj.Status.HasFinished() {


### PR DESCRIPTION
## Summary
RequeueAfter the cr object if it's status is Started

fixes #830 
Signed-off-by: acechef <simba_cc@163.com>
## Checklist

### For Code changes

- [x] Categorize the PR by setting a good title and adding one of the labels:
  `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
  as they show up in the changelog
- [x] PR contains the label `area:operator`
- [x] Link this PR to related issues
- [x] I have not made _any_ changes in the `charts/` directory.

### For Helm Chart changes

- [ ] Categorize the PR by setting a good title and adding one of the labels:
  `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
  as they show up in the changelog
- [ ] PR contains the label `area:chart`
- [ ] PR contains the chart label, e.g. `chart:k8up`
- [ ] Variables are documented in the values.yaml using the format required by [Helm-Docs](https://github.com/norwoodj/helm-docs#valuesyaml-metadata).
- [ ] Chart Version bumped if immediate release after merging is planned
- [ ] I have run `make chart-docs`
- [ ] Link this PR to related code release or other issues.

<!--
NOTE:
Do *not* mix code changes with chart changes, it will break the release process.
Delete the checklist section that doesn't apply to the change.

NOTE:
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
