### PR TITLE
Installation of K8up CLI and updated version numbers for preview images

### DIFF
--- a/docs/docs.mk
+++ b/docs/docs.mk
@@ -6,19 +6,19 @@ out_dir := ./_public
 docker_cmd  ?= docker
 docker_opts ?= --rm --tty --user "$$(id -u)"
 
-antora_cmd  ?= $(docker_cmd) run $(docker_opts) --volume "$${PWD}":/antora vshn/antora:2.3.3
+antora_cmd  ?= $(docker_cmd) run $(docker_opts) --volume "$${PWD}":/antora ghcr.io/vshn/antora:3.1.2.2
 antora_opts ?= --cache-dir=.cache/antora
 
 asciidoctor_cmd  ?= $(docker_cmd) run $(docker_opts) --volume "$${PWD}":/documents/ asciidoctor/docker-asciidoctor asciidoctor
-asciidoctor_pdf_cmd  ?= $(docker_cmd) run $(docker_opts) --volume "$${PWD}":/documents/ vshn/asciidoctor-pdf:1.8.1 --attribute toclevels=1
-asciidoctor_epub3_cmd  ?= $(docker_cmd) run $(docker_opts) --volume "$${PWD}":/documents/ vshn/asciidoctor-epub3:1.8.1 --attribute toclevels=1
+asciidoctor_pdf_cmd  ?= $(docker_cmd) run $(docker_opts) --volume "$${PWD}":/documents/ ghcr.io/vshn/asciidoctor-pdf:1.39.1 --attribute toclevels=1
+asciidoctor_epub3_cmd  ?= $(docker_cmd) run $(docker_opts) --volume "$${PWD}":/documents/ ghcr.io/vshn/asciidoctor-epub3:1.39.1 --attribute toclevels=1
 asciidoctor_opts ?= --destination-dir=$(out_dir)
 asciidoctor_kindle_opts ?= --attribute ebook-format=kf8
 
-vale_cmd ?= $(docker_cmd) run $(docker_opts) --volume "$${PWD}"/src/modules/ROOT/pages:/pages vshn/vale:2.6.1 --minAlertLevel=error /pages
-hunspell_cmd ?= $(docker_cmd) run $(docker_opts) --volume "$${PWD}":/spell vshn/hunspell:1.7.0 -d en,vshn -l -H _public/**/**/*.html
+vale_cmd ?= $(docker_cmd) run $(docker_opts) --volume "$${PWD}"/src/modules/ROOT/pages:/pages ghcr.io/vshn/vale:2.15.5 --minAlertLevel=error /pages
+hunspell_cmd ?= $(docker_cmd) run $(docker_opts) --volume "$${PWD}":/spell ghcr.io/vshn/hunspell:1.7.0.2 -d en,vshn -l -H _public/**/**/*.html
 htmltest_cmd ?= $(docker_cmd) run $(docker_opts) --volume "$${PWD}"/_public:/test wjdp/htmltest:v0.12.0
-preview_cmd ?= $(docker_cmd) run --rm --publish 35729:35729 --publish 2020:2020 --volume "${PWD}":/preview/antora vshn/antora-preview:3.1.2.2 --antora=docs --style=k8up
+preview_cmd ?= $(docker_cmd) run --rm --publish 35729:35729 --publish 2020:2020 --volume "${PWD}":/preview/antora ghcr.io/vshn/antora-preview:3.1.2.3 --antora=docs --style=k8up
 
 docs_usage_dir ?= docs/modules/ROOT/examples/usage
 

--- a/docs/docs.mk
+++ b/docs/docs.mk
@@ -15,7 +15,7 @@ asciidoctor_epub3_cmd  ?= $(docker_cmd) run $(docker_opts) --volume "$${PWD}":/d
 asciidoctor_opts ?= --destination-dir=$(out_dir)
 asciidoctor_kindle_opts ?= --attribute ebook-format=kf8
 
-vale_cmd ?= $(docker_cmd) run $(docker_opts) --volume "$${PWD}"/src/modules/ROOT/pages:/pages ghcr.io/vshn/vale:2.15.5 --minAlertLevel=error /pages
+vale_cmd ?= $(docker_cmd) run $(docker_opts) --volume "$${PWD}"/docs/modules/ROOT/pages:/pages --workdir /pages ghcr.io/vshn/vale:2.15.5 --minAlertLevel=error .
 hunspell_cmd ?= $(docker_cmd) run $(docker_opts) --volume "$${PWD}":/spell ghcr.io/vshn/hunspell:1.7.0.2 -d en,vshn -l -H _public/**/**/*.html
 htmltest_cmd ?= $(docker_cmd) run $(docker_opts) --volume "$${PWD}"/_public:/test wjdp/htmltest:v0.12.0
 preview_cmd ?= $(docker_cmd) run --rm --publish 35729:35729 --publish 2020:2020 --volume "${PWD}":/preview/antora ghcr.io/vshn/antora-preview:3.1.2.3 --antora=docs --style=k8up

--- a/docs/modules/ROOT/pages/.vale.ini
+++ b/docs/modules/ROOT/pages/.vale.ini
@@ -3,7 +3,8 @@ MinAlertLevel = warning # suggestion, warning or error
 
 # Only check Asciidoc files
 [*.adoc]
-
-# Using the Microsoft style
 BasedOnStyles = Microsoft
 Microsoft.GenderBias = warning
+Microsoft.Contractions = warning
+Microsoft.Quotes = warning
+Microsoft.RangeFormat = warning

--- a/docs/modules/ROOT/pages/how-tos/installation.adoc
+++ b/docs/modules/ROOT/pages/how-tos/installation.adoc
@@ -2,17 +2,23 @@
 
 == Helm
 
-The most convenient way to install K8up is using https://helm.sh/[helm].
+The most convenient way to install K8up on your Kubernetes cluster is by using https://helm.sh/[helm].
 
 Please refer to the separate installation instructions in the https://github.com/k8up-io/k8up/tree/master/charts/k8up[Helm chart].
 
+== Command-Line Tool (CLI)
+
+The command-line tool can be downloaded from the https://github.com/k8up-io/k8up/releases["Releases" page on GitHub], and installed in your `$PATH`.
+
+After installation, run the `k8up --version` command to make sure it is properly installed.
+
 == Samples
 
-Some K8up examples are located at `config/samples/` in the K8up repository:
+You can find some examples of use of K8up in the `config/samples/` folder of the K8up repository:
 
 [source,bash]
 ----
 kubectl apply -k config/samples/
 ----
 
-Please be aware that these manifests are intended for dev and as examples.
+Please be aware that these manifests are intended for testing, development, and as examples.


### PR DESCRIPTION
## Summary

* Adds a section explaining how to install the K8up CLI tool closing #840
* Updates the container images used for Antora preview to their latest versions

## Checklist

### For Code changes

- [x] Categorize the PR by setting a good title and adding one of the labels:
  `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
  as they show up in the changelog
- [ ] PR contains the label `area:operator`
- [x] Link this PR to related issues
- [x] I have not made _any_ changes in the `charts/` directory.

### For Helm Chart changes

- [ ] Categorize the PR by setting a good title and adding one of the labels:
  `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
  as they show up in the changelog
- [ ] PR contains the label `area:chart`
- [ ] PR contains the chart label, e.g. `chart:k8up`
- [ ] Variables are documented in the values.yaml using the format required by [Helm-Docs](https://github.com/norwoodj/helm-docs#valuesyaml-metadata).
- [ ] Chart Version bumped if immediate release after merging is planned
- [ ] I have run `make chart-docs`
- [ ] Link this PR to related code release or other issues.

