### PR TITLE
Add darwin and windows to GOOS build targets

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -11,7 +11,9 @@ builds:
   - amd64
   - arm64
   goos:
+  - darwin
   - linux
+  - windows
 
 checksum:
   name_template: 'checksums.txt'


### PR DESCRIPTION
## Summary

* Add darwin and windows to GOOS build targets
* Fixes #839

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
  `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
  as they show up in the changelog
- [x] PR contains the label `area:operator`
- [x] Link this PR to related issues
- [x] I have not made _any_ changes in the `charts/` directory.
