### PR TITLE
Improve RBAC for the operator

### DIFF
--- a/charts/k8up/templates/executor-clusterrole.yaml
+++ b/charts/k8up/templates/executor-clusterrole.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.rbac.create -}}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: 'k8up-executor'
+  labels:
+    {{- include "k8up.labels" . | nindent 4 }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+  - apiGroups:
+      - ""
+    resources:
+      - pods/exec
+    verbs:
+      - create
+  - apiGroups:
+      - k8up.io
+    resources:
+      - snapshots
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+{{- end -}}

--- a/charts/k8up/templates/operator-clusterrole.yaml
+++ b/charts/k8up/templates/operator-clusterrole.yaml
@@ -68,13 +68,9 @@ rules:
     resources:
       - pods
     verbs:
-      - '*'
-  - apiGroups:
-      - ""
-    resources:
-      - pods/exec
-    verbs:
-      - '*'
+      - get
+      - list
+      - watch
   - apiGroups:
       - ""
     resources:
@@ -273,9 +269,16 @@ rules:
       - update
   - apiGroups:
       - rbac.authorization.k8s.io
+    resourceNames:
+      - k8up-executor
+    resources:
+      - clusterroles
+    verbs:
+      - bind
+  - apiGroups:
+      - rbac.authorization.k8s.io
     resources:
       - rolebindings
-      - roles
     verbs:
       - create
       - delete

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -66,13 +66,9 @@ rules:
   resources:
   - pods
   verbs:
-  - '*'
-- apiGroups:
-  - ""
-  resources:
-  - pods/exec
-  verbs:
-  - '*'
+  - get
+  - list
+  - watch
 - apiGroups:
   - ""
   resources:
@@ -271,9 +267,16 @@ rules:
   - update
 - apiGroups:
   - rbac.authorization.k8s.io
+  resourceNames:
+  - k8up-executor
+  resources:
+  - clusterroles
+  verbs:
+  - bind
+- apiGroups:
+  - rbac.authorization.k8s.io
   resources:
   - rolebindings
-  - roles
   verbs:
   - create
   - delete

--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -25,6 +25,7 @@ kind-load-image: kind-setup docker-build ## Load the e2e container image onto e2
 
 .PHONY: e2e-setup
 e2e-setup: export KUBECONFIG = $(KIND_KUBECONFIG)
+e2e-setup: chart-prepare
 e2e-setup: e2e/node_modules kind-setup | $(e2etest_dir) ## Run the e2e setup
 
 .PHONY: clean

--- a/e2e/lib/k8up.bash
+++ b/e2e/lib/k8up.bash
@@ -194,6 +194,8 @@ given_a_running_operator() {
 	replace_in_file ${values_tgt} E2E_REPO "${IMG_REPO}"
 	replace_in_file ${values_tgt} E2E_TAG "${IMG_TAG}"
 
+	helm uninstall -n k8up-system k8up || true
+
 	helm upgrade --install k8up ../charts/k8up \
 		--create-namespace \
 		--namespace k8up-system \

--- a/operator/backupcontroller/backup_utils.go
+++ b/operator/backupcontroller/backup_utils.go
@@ -50,38 +50,6 @@ func (b *BackupExecutor) createServiceAccountAndBinding(ctx context.Context) err
 		return err
 	}
 
-	role := &rbacv1.Role{}
-	role.Name = cfg.Config.PodExecRoleName
-	role.Namespace = b.backup.Namespace
-	_, err = controllerruntime.CreateOrUpdate(ctx, b.Config.Client, role, func() error {
-		role.Rules = []rbacv1.PolicyRule{
-			{
-				APIGroups: []string{""},
-				Resources: []string{"pods", "pods/exec"},
-				Verbs:     []string{"*"},
-			},
-			{
-				APIGroups: []string{"k8up.io"},
-				Resources: []string{"snapshots"},
-				Verbs: []string{
-					"create",
-					"delete",
-					"get",
-					"list",
-					"patch",
-					"update",
-					"watch",
-				},
-			},
-			{
-				APIGroups: []string{"k8up.io"},
-				Resources: []string{"snapshots/finalizers", "snapshots/status"},
-				Verbs:     []string{"get", "patch", "update"},
-			},
-		}
-		return nil
-	})
-
 	if err != nil {
 		return err
 	}
@@ -97,8 +65,8 @@ func (b *BackupExecutor) createServiceAccountAndBinding(ctx context.Context) err
 			},
 		}
 		roleBinding.RoleRef = rbacv1.RoleRef{
-			Kind:     "Role",
-			Name:     role.Name,
+			Kind:     "ClusterRole",
+			Name:     "k8up-executor",
 			APIGroup: "rbac.authorization.k8s.io",
 		}
 		return nil

--- a/operator/backupcontroller/setup.go
+++ b/operator/backupcontroller/setup.go
@@ -14,12 +14,12 @@ import (
 // +kubebuilder:rbac:groups=k8up.io,resources=prebackuppods/status;prebackuppods/finalizers,verbs=get;update;patch
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=batch,resources=jobs,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=core,resources=pods,verbs="*"
-// +kubebuilder:rbac:groups=core,resources=pods/exec,verbs="*"
+// +kubebuilder:rbac:groups=core,resources=pods,verbs=list;get;watch
 // +kubebuilder:rbac:groups=core,resources=serviceaccounts,verbs=get;list;watch;create;delete
 // +kubebuilder:rbac:groups=core,resources=persistentvolumeclaims,verbs=get;list;watch
 // +kubebuilder:rbac:groups=core,resources=persistentvolumes,verbs=get;list;watch
-// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles;rolebindings,verbs=get;list;watch;create;delete;update
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings,verbs=get;list;watch;create;delete;update
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles,verbs=bind,resourceNames=k8up-executor
 
 // SetupWithManager configures the reconciler.
 func SetupWithManager(mgr controllerruntime.Manager) error {


### PR DESCRIPTION
## Summary

Previously the operator had the `pod/exe` permissions with the verb
`create`. Which is necessary for K8up to create and bind the namespaced
roles where the actual backups happen.
    
To harden the RBAC a bit we're now deploying a clusterRole which
contains the necessary RBAC rules. Also K8up is now allowed to bind
exactly this clusterRole.
    
While this doesn't mitigate all potential exploits in case the K8up
operator pod is accessed by a malicious party, it makes it harder for
the malicious party to abuse K8up's permissions.

## Checklist

### For Code changes

- [x] Categorize the PR by setting a good title and adding one of the labels:
  `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
  as they show up in the changelog
- [x] PR contains the label `area:operator`
- [x] Link this PR to related issues
- [ ] I have not made _any_ changes in the `charts/` directory.

