### PR TITLE
Add helm hooks to cleanup operator generated objects

### DIFF
--- a/charts/k8up/Chart.yaml
+++ b/charts/k8up/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
   - backup
   - operator
   - restic
-version: 4.2.2
+version: 4.3.0
 sources:
   - https://github.com/k8up-io/k8up
 maintainers:

--- a/charts/k8up/README.md
+++ b/charts/k8up/README.md
@@ -1,6 +1,6 @@
 # k8up
 
-![Version: 4.2.2](https://img.shields.io/badge/Version-4.2.2-informational?style=flat-square)
+![Version: 4.3.0](https://img.shields.io/badge/Version-4.3.0-informational?style=flat-square)
 
 Kubernetes and OpenShift Backup Operator based on restic
 
@@ -13,7 +13,7 @@ helm repo add k8up-io https://k8up-io.github.io/k8up
 helm install k8up k8up-io/k8up
 ```
 ```bash
-kubectl apply -f https://github.com/k8up-io/k8up/releases/download/k8up-4.2.2/k8up-crd.yaml
+kubectl apply -f https://github.com/k8up-io/k8up/releases/download/k8up-4.3.0/k8up-crd.yaml
 ```
 
 <!---

--- a/charts/k8up/templates/cleanup-hook.yaml
+++ b/charts/k8up/templates/cleanup-hook.yaml
@@ -1,0 +1,100 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cleanup-service-account
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade,post-delete
+    "helm.sh/hook-weight": "1"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+  labels:
+{{ include "k8up.labels" . | indent 4 }}
+
+---
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: k8up-cleanup-roles
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade,post-delete
+    "helm.sh/hook-weight": "2"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+  labels:
+    {{- include "k8up.labels" . | nindent 4 }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+    verbs:
+      - get
+      - list
+  - apiGroups:
+      - "rbac.authorization.k8s.io"
+    resources:
+      - rolebindings
+      - roles
+    verbs:
+      - delete
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cleanup-rolebinding
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade,post-delete
+    "helm.sh/hook-weight": "3"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+  labels:
+    {{- include "k8up.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: k8up-cleanup-roles
+subjects:
+- kind: ServiceAccount
+  name: cleanup-service-account
+  namespace: {{ .Release.Namespace }}
+
+---
+
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "{{ .Release.Name }}-cleanup"
+  labels:
+    {{- include "k8up.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade,post-delete
+    "helm.sh/hook-weight": "4"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  template:
+    metadata:
+      name: "{{ .Release.Name }}"
+      labels:
+        {{- include "k8up.selectorLabels" . | nindent 8 }}
+    spec:
+      restartPolicy: Never
+      serviceAccountName: cleanup-service-account
+      containers:
+      - name: "{{ .Release.Name }}-cleanup"
+        image: "bitnami/kubectl:latest"
+        command:
+          - sh
+          - -c
+        args:
+          - |
+            #!/bin/bash
+
+            NAMESPACES=$(kubectl get namespace -ojson | jq -r '.items[].metadata.name')
+
+            for ns in $NAMESPACES
+            do
+              kubectl -n "$ns" delete rolebinding pod-executor-namespaced --ignore-not-found=true
+              kubectl -n "$ns" delete role pod-executor --ignore-not-found=true
+            done


### PR DESCRIPTION
## Summary

* There have been various issues with leftover rolebindings and roles lately. To mitigate those issues the helm chart now does a cleanup of those in all namespaces.

Fixes: #859

## Checklist

### For Helm Chart changes

- [x] Categorize the PR by setting a good title and adding one of the labels:
  `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
  as they show up in the changelog
- [x] PR contains the label `area:chart`
- [x] PR contains the chart label, e.g. `chart:k8up`
- [x] Variables are documented in the values.yaml using the format required by [Helm-Docs](https://github.com/norwoodj/helm-docs#valuesyaml-metadata).
- [x] Chart Version bumped if immediate release after merging is planned
- [x] I have run `make chart-docs`
- [x] Link this PR to related code release or other issues.

<!--
NOTE:
Do *not* mix code changes with chart changes, it will break the release process.
Delete the checklist section that doesn't apply to the change.

NOTE:
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
