### PR TITLE
Don't drop the backend configuration for archives

### DIFF
--- a/operator/archivecontroller/executor.go
+++ b/operator/archivecontroller/executor.go
@@ -100,6 +100,13 @@ func (a *ArchiveExecutor) setupEnvVars(ctx context.Context, archive *k8upv1.Arch
 		}
 	}
 
+	if archive.Spec.Backend != nil {
+		for key, value := range archive.Spec.Backend.GetCredentialEnv() {
+			vars.SetEnvVarSource(key, value)
+		}
+		vars.SetString(cfg.ResticRepositoryEnvName, archive.Spec.Backend.String())
+	}
+
 	err := vars.Merge(executor.DefaultEnv(a.Obj.GetNamespace()))
 	if err != nil {
 		log.Error(err, "error while merging the environment variables", "name", a.Obj.GetName(), "namespace", a.Obj.GetNamespace())


### PR DESCRIPTION
## Summary
The operator didn't add the backend (source) environment variables to the resulting pod. This resulted in broken archive jobs where Restic was not able to read the actual backup data.

This commit fixes this issue by actually adding the correct backend env variables.


## Checklist

### For Code changes

- [x] Categorize the PR by setting a good title and adding one of the labels:
  `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
  as they show up in the changelog
- [x] PR contains the label `area:operator`
- [x] Link this PR to related issues
- [x] I have not made _any_ changes in the `charts/` directory.

