### PR TITLE
Fix documentation writing style issues

### DIFF
--- a/docs/modules/ROOT/pages/about/contribution_guide.adoc
+++ b/docs/modules/ROOT/pages/about/contribution_guide.adoc
@@ -67,7 +67,7 @@ If you set your `user.name` and `user.email` git configs, you can sign your comm
 Some K8up contributors might not be familiar with `git`, or have used a web based editor, and thus asking them to `git commit --amend -s` is not the best way forward.
 
 In this case, maintainers can update the commits based on clause (c) of the DCO.
-The most trivial way for a contributor to allow the maintainer to do this, is to add a DCO signature in a pull requests's comment, or a maintainer can simply note that the change is sufficiently trivial that it does not substantially change the existing contribution - i.e., a spelling change.
+The most trivial way for a contributor to allow the maintainer to do this, is to add a DCO signature in a pull requests's comment, or a maintainer can simply note that the change is sufficiently trivial that it does not substantially change the existing contribution - for example a spelling change.
 
 When you add someone's DCO, please also add your own to keep a log.
 

--- a/docs/modules/ROOT/pages/explanations/backup.adoc
+++ b/docs/modules/ROOT/pages/explanations/backup.adoc
@@ -46,7 +46,7 @@ It also works with a variety of database systems and likewise programs that stor
 The drawback is that it transfers data via `stdout`, which is less efficient.
 The reason is that Kubernetes has to relay that data from the executed command to K8up.
 Another drawback is that your `Pod` must provide the tools to execute the command.
-If it does not already contain that command – if it's a distro-less container for example – then the next method might be for you.
+If it does not already contain that command, for example if it's a distro-less container, then the next method might be for you.
 
 Read xref:how-tos/application-aware-backups.adoc[] to learn more about to use this backup method.
 
@@ -63,7 +63,7 @@ You can provide a special image which contains all the commands you need.
 You can access your `Secrets`.
 You can connect to services inside or outside the cluster, like a managed database.
 
-The drawback – in contrast to the pure _backup command_ – is that this `Pod` runs in its own context and can't access services which are internal to another _Pod_.
+The drawback, in contrast to the pure _backup command_, is that this `Pod` runs in its own context and can't access services which are internal to another _Pod_.
 You may also need to keep the `PreBackupPod` in sync with your main `Deployment` or with an external dependency.
 When you update your database in your main `Deployment` for example, you may need to update your `PreBackupPod` as well.
 

--- a/docs/modules/ROOT/pages/explanations/ide.adoc
+++ b/docs/modules/ROOT/pages/explanations/ide.adoc
@@ -14,11 +14,11 @@ Just in order to run the integration tests you will need to do some extra config
 .. Put `integration` into _Custom tags_
 . Now try to run a specific integration test.
 
-You can use all the usual shortcuts to quickly run a test (e.g. kbd:[Ctrl+Shift+D] to debug a specific test method).
+You can use all the usual shortcuts to quickly run a test (for example kbd:[Ctrl+Shift+D] to debug a specific test method).
 If it doesn't work, check the following:
 
 . Check that the _Custom tags_ field in _Preferences_ → _Go_ → _Build Tags & Vendoring_ contains to term `integration`.
-. Make sure the _Working directory_ of your test's _Run Configuration_ points to the directory where your test lies, e.g. `/home/your_user/projects/k8up/controllers`.
+. Make sure the _Working directory_ of your test's _Run Configuration_ points to the directory where your test lies, for example `/home/your_user/projects/k8up/controllers`.
 . Try to tick _Use all custom build tags_ checkbox in your test's _Run Configuration_.
 
 [IMPORTANT]

--- a/docs/modules/ROOT/pages/explanations/missing-docs.adoc
+++ b/docs/modules/ROOT/pages/explanations/missing-docs.adoc
@@ -3,7 +3,7 @@
 For the following keywords documentation is missing and will be added over time.
 This should give you an idea what is included, but currently not documented.
 
-* Describe prune and check jobs and their implications (e.g. locking)
+* Describe prune and check jobs and their implications (for example locking)
 * Webhooks with backup information
 * Prometheus Metrics of Operator
 * Prometheus Pushgateway metrics of `k8up restic`

--- a/docs/modules/ROOT/pages/how-tos/application-aware-backups.adoc
+++ b/docs/modules/ROOT/pages/how-tos/application-aware-backups.adoc
@@ -18,7 +18,7 @@ template:
 ----
 
 With this annotation the Operator will trigger that command inside the the container and capture the stdout to a backup.
-The command is only executed on one Pod, if there are multiple Pods with the same owner reference (e.g. Deployments, Statefulsets etc).
+The command is only executed on one Pod, if there are multiple Pods with the same owner reference (for example Deployments, Statefulsets etc).
 
 Tested with:
 

--- a/docs/modules/ROOT/pages/how-tos/optimize-schedules.adoc
+++ b/docs/modules/ROOT/pages/how-tos/optimize-schedules.adoc
@@ -6,7 +6,7 @@ When you start having hundreds of backup, check, prune or archive schedules it c
 However, manually trying to balance the schedules to different times is no solution either.
 
 Enter smart schedules.
-In addition to the standard Cron syntax (e.g. `* */12 * * *`) K8up features stable randomization of schedules.
+In addition to the standard Cron syntax (for example `* */12 * * *`) K8up features stable randomization of schedules.
 Enter a special `-random`-suffixed schedule to your spec in order to let K8up generate a schedule for you.
 
 A schedule of `@weekly-random` generates an effective schedule like `52 4 * * 4`.

--- a/docs/modules/ROOT/pages/references/annotations.adoc
+++ b/docs/modules/ROOT/pages/references/annotations.adoc
@@ -19,7 +19,7 @@ See xref:references/operator-config-reference.adoc[Operator Configuration refere
 
 |`k8up.io/backupcommand`
 |If defined, this command is invoked in the context of this `Pod` on the beginning of a backup.
-|A string that represents a command (and its arguments) to execute, e.g. `mysqldump -uroot -psecure --all-databases`.
+|A string that represents a command (and its arguments) to execute, for example `mysqldump -uroot -psecure --all-databases`.
  See xref:how-tos/application-aware-backups.adoc[Application Aware Backups] for more information and an example.
 |`Pod`
 |`BACKUP_BACKUPCOMMANDANNOTATION`
@@ -27,7 +27,7 @@ See xref:references/operator-config-reference.adoc[Operator Configuration refere
 |`k8up.io/file-extension`
 |The output of the `k8up.syn.tool/backupcommand` annotation is written to a file in order for it to be backed up.
  This annotation defines the file extension of that string.
-|A string which is valid file-extension on the source system, e.g. `.sql`.
+|A string which is valid file-extension on the source system, for example `.sql`.
 |`Pod`
 |`BACKUP_FILEEXTENSIONANNOTATION`
 

--- a/docs/modules/ROOT/pages/references/object-specifications.adoc
+++ b/docs/modules/ROOT/pages/references/object-specifications.adoc
@@ -484,6 +484,6 @@ include::example$references/effective-schedule.yaml[]
 
 === Settings
 
-* `spec.generatedSchedule`: schedule definition that was translated, e.g. from `@hourly-random` to `4 * * * *`.
+* `spec.generatedSchedule`: schedule definition that was translated, for example from `@hourly-random` to `4 * * * *`.
 * `spec.jobType`: The K8up job type this resource is applicable to.
 * `spec.scheduleRefs`: A list of `Schedules` for which the generated schedule applies to.

--- a/docs/modules/ROOT/pages/references/schedule-specification.adoc
+++ b/docs/modules/ROOT/pages/references/schedule-specification.adoc
@@ -1,7 +1,7 @@
 = Schedule Specification
 
 K8up comes with its own integrated scheduler and supports more advanced schedule specifications.
-The standard Cron syntax (e.g. `0 */12 * * *`) is supported (see https://en.wikipedia.org/wiki/Cron[Wikipedia])
+The standard Cron syntax (for example `0 */12 * * *`) is supported (see https://en.wikipedia.org/wiki/Cron[Wikipedia])
 
 All interpretation and scheduling is done in the machine's local time zone, as provided by the http://www.golang.org/pkg/time[Go time package].
 
@@ -33,7 +33,7 @@ The following non-standard schedules are supported:
 
 |`@every <duration>`
 |Run once at fixed intervals, starting at the time it's added or K8up is started up.
- `<duration>` is a string accepted by http://golang.org/pkg/time/#ParseDuration[time.ParseDuration] (e.g. `1h30m`).
+ `<duration>` is a string accepted by http://golang.org/pkg/time/#ParseDuration[`time.ParseDuration`] (for example `1h30m`).
 |
 |===
 

--- a/docs/modules/ROOT/pages/tutorials/tutorial.adoc
+++ b/docs/modules/ROOT/pages/tutorials/tutorial.adoc
@@ -85,7 +85,7 @@ IMPORTANT: On some laptops, running Minikube on battery power severely undermine
 
 After finishing all these steps, check that everything is running.
 Simply launch `k9s` and leave it running in its own terminal window.
-Or – of course – you can use the usual `kubectl get pods` to check how your components are doing.
+Or you can use the usual `kubectl get pods` to check how your components are doing.
 
 The https://asciinema.org/[asciinema] movie below shows all of these steps in real time.
 


### PR DESCRIPTION
We enabled vale linting for documentation on CI. Vale found a couple of issues, that we fix with this commit.

Related to the CI provement PR: https://github.com/k8up-io/k8up/pull/869  showing that it's working

## Checklist

### For Code changes

- [x] Categorize the PR by setting a good title and adding one of the labels:
  `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
  as they show up in the changelog
- [ ] PR contains the label `area:operator`
- [x] Link this PR to related issues
- [x] I have not made _any_ changes in the `charts/` directory.


<!--
NOTE:
Do *not* mix code changes with chart changes, it will break the release process.
Delete the checklist section that doesn't apply to the change.

NOTE:
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
