### PR TITLE
Added service account annotations

### DIFF
--- a/charts/k8up/README.md
+++ b/charts/k8up/README.md
@@ -80,6 +80,7 @@ Document your changes in values.yaml and let `make docs:helm` generate this sect
 | resources.requests.cpu | string | `"20m"` | CPU request of K8up operator. See [supported units][resource-units]. |
 | resources.requests.memory | string | `"128Mi"` | Memory request of K8up operator. See [supported units][resource-units]. |
 | securityContext | object | `{}` | Container security context |
+| serviceAccount.annotations | object | `{}` | Annotations to add to the service account. |
 | serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
 | serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template |
 | tolerations | list | `[]` |  |

--- a/charts/k8up/templates/serviceaccount.yaml
+++ b/charts/k8up/templates/serviceaccount.yaml
@@ -5,4 +5,9 @@ metadata:
   name: {{ template "k8up.serviceAccountName" . }}
   labels:
 {{ include "k8up.labels" . | indent 4 }}
+{{- with .Values.serviceAccount.annotations }}
+annotations:
+  {{- toYaml . | nindent 4 }}
+{{- end }}
+
 {{- end -}}

--- a/charts/k8up/values.yaml
+++ b/charts/k8up/values.yaml
@@ -19,8 +19,8 @@ serviceAccount:
   # -- The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
   name: ""
+  # -- Annotations to add to the service account.
   annotations: {}
-  # -- Extra Labels to add to the service account.
 
 k8up:
   # -- envVars allows the specification of additional environment variables.

--- a/charts/k8up/values.yaml
+++ b/charts/k8up/values.yaml
@@ -19,6 +19,8 @@ serviceAccount:
   # -- The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
   name: ""
+  annotations: {}
+  # -- Extra Labels to add to the service account.
 
 k8up:
   # -- envVars allows the specification of additional environment variables.


### PR DESCRIPTION
## Summary

Helm chart service account annotation. Needed for EKS IRSA roles. I took code from:
https://github.com/external-secrets/external-secrets/blob/main/deploy/charts/external-secrets/values.yaml#L78
https://github.com/external-secrets/external-secrets/blob/main/deploy/charts/external-secrets/templates/serviceaccount.yaml#L12
