### PR TITLE
Fix indentation of the sa annotations

### DIFF
--- a/charts/k8up/Chart.yaml
+++ b/charts/k8up/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
   - backup
   - operator
   - restic
-version: 4.4.0
+version: 4.4.1
 sources:
   - https://github.com/k8up-io/k8up
 maintainers:

--- a/charts/k8up/README.md
+++ b/charts/k8up/README.md
@@ -1,6 +1,6 @@
 # k8up
 
-![Version: 4.4.0](https://img.shields.io/badge/Version-4.4.0-informational?style=flat-square)
+![Version: 4.4.1](https://img.shields.io/badge/Version-4.4.1-informational?style=flat-square)
 
 Kubernetes and OpenShift Backup Operator based on restic
 
@@ -13,7 +13,7 @@ helm repo add k8up-io https://k8up-io.github.io/k8up
 helm install k8up k8up-io/k8up
 ```
 ```bash
-kubectl apply -f https://github.com/k8up-io/k8up/releases/download/k8up-4.4.0/k8up-crd.yaml
+kubectl apply -f https://github.com/k8up-io/k8up/releases/download/k8up-4.4.1/k8up-crd.yaml
 ```
 
 <!---

--- a/charts/k8up/templates/serviceaccount.yaml
+++ b/charts/k8up/templates/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
 {{ include "k8up.labels" . | indent 4 }}
 {{- with .Values.serviceAccount.annotations }}
-annotations:
+  annotations:
   {{- toYaml . | nindent 4 }}
 {{- end }}
 


### PR DESCRIPTION
## Summary

* The indentation for the sa annotations was wrong.

Fixes issue found in: #876

## Checklist

### For Helm Chart changes

- [x] Categorize the PR by setting a good title and adding one of the labels:
  `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
  as they show up in the changelog
- [x] PR contains the label `area:chart`
- [x] PR contains the chart label, e.g. `chart:k8up`
- [x] Variables are documented in the values.yaml using the format required by [Helm-Docs](https://github.com/norwoodj/helm-docs#valuesyaml-metadata).
- [x] Chart Version bumped if immediate release after merging is planned
- [x] I have run `make chart-docs`
- [x] Link this PR to related code release or other issues.

<!--
NOTE:
Do *not* mix code changes with chart changes, it will break the release process.
Delete the checklist section that doesn't apply to the change.

NOTE:
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
