### PR TITLE
Typo fixes for possessive 'its'

### DIFF
--- a/docs/modules/ROOT/pages/explanations/architecture.adoc
+++ b/docs/modules/ROOT/pages/explanations/architecture.adoc
@@ -57,4 +57,4 @@ It uses the same Docker image as the `k8up operator`.
 While `k8up operator` is usually running for a long time, `k8up restic` will do the job it is tasked to do and then exit.
 It also does not modify any resources in the Kubernetes cluster or leave permanent traces.
 But it will look for `Pod` resources xref:references/annotations.adoc[that are annotated].
-And it will also create one-off containers in the `Pod` resources it finds that are annotated with `k8up.io/backupcommand` in order to run the respective backup command and collect it's output.
+And it will also create one-off containers in the `Pod` resources it finds that are annotated with `k8up.io/backupcommand` in order to run the respective backup command and collect its output.

--- a/docs/modules/ROOT/pages/explanations/what-has-changed-in-v2.adoc
+++ b/docs/modules/ROOT/pages/explanations/what-has-changed-in-v2.adoc
@@ -3,7 +3,7 @@
 TIP: See xref:how-tos/upgrade.adoc#upgrade_1_to_2[the upgrade instructions] for detailed instructions about how to upgrade from version `0.x` to `1.x`.
 
 https://github.com/k8up-io/k8up/releases/tag/v2.0.0[K8up v2.0] is another milestone for K8up.
-Because of the move to it's own GitHub organization, some resources have been renamed.
+Because of the move to its own GitHub organization, some resources have been renamed.
 This makes K8up `2.x` incompatible with previous resources.
 
 Previously, the code that invoked the `restic` binary was in its own project, which was called `wrestic`.

--- a/docs/modules/ROOT/pages/how-tos/upgrade.adoc
+++ b/docs/modules/ROOT/pages/how-tos/upgrade.adoc
@@ -7,12 +7,12 @@ WARNING: Never remove the CRDs, as you might lose the respective resources!
 
 TIP: See also xref:explanations/what-has-changed-in-v2.adoc[].
 
-Because of the move of K8up to it's own GitHub organization, and a cleanup of several namings, there are visible changes from a user's perspective in K8up 2.x, which require (manual) intervention for a successful upgrade.
+Because of the move of K8up to its own GitHub organization, and a cleanup of several namings, there are visible changes from a user's perspective in K8up 2.x, which require (manual) intervention for a successful upgrade.
 These changes require you to update your configuration of K8up.
 
 === Move to our own GitHub organization
 
-We have moved K8up into it's own https://github.com/k8up-io[GitHub organization].
+We have moved K8up into its own https://github.com/k8up-io[GitHub organization].
 As a result, we also updated some names.
 
 - In the CRD definition, what was `backup.appuio.ch` is now `k8up.io`.

--- a/docs/modules/ROOT/pages/tutorials/tutorial.adoc
+++ b/docs/modules/ROOT/pages/tutorials/tutorial.adoc
@@ -140,7 +140,7 @@ image::tutorial/wordpress-install.png[]
 [[step_3]]
 === Backing up the blog
 
-In this step we're going to create a backup of our blog and it's database.
+In this step we're going to create a backup of our blog and its database.
 Everything related to this is defined in `backup.yml`.
 Once applied to our Minikube cluster,
 k8up will instantly take a backup of the database


### PR DESCRIPTION
## Summary

* Fixes possessive "it's" -> "its"

