### PR TITLE
fix: Add values to overwrite cleanup image

### DIFF
--- a/charts/k8up/Chart.yaml
+++ b/charts/k8up/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
   - backup
   - operator
   - restic
-version: 4.4.1
+version: 4.4.2
 sources:
   - https://github.com/k8up-io/k8up
 maintainers:

--- a/charts/k8up/README.md
+++ b/charts/k8up/README.md
@@ -1,6 +1,6 @@
 # k8up
 
-![Version: 4.4.1](https://img.shields.io/badge/Version-4.4.1-informational?style=flat-square)
+![Version: 4.4.2](https://img.shields.io/badge/Version-4.4.2-informational?style=flat-square)
 
 Kubernetes and OpenShift Backup Operator based on restic
 
@@ -13,7 +13,7 @@ helm repo add k8up-io https://k8up-io.github.io/k8up
 helm install k8up k8up-io/k8up
 ```
 ```bash
-kubectl apply -f https://github.com/k8up-io/k8up/releases/download/k8up-4.4.1/k8up-crd.yaml
+kubectl apply -f https://github.com/k8up-io/k8up/releases/download/k8up-4.4.2/k8up-crd.yaml
 ```
 
 <!---
@@ -41,6 +41,10 @@ Document your changes in values.yaml and let `make docs:helm` generate this sect
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` |  |
+| cleanup.pullPolicy | string | `"IfNotPresent"` | Cleanup-job image pull policy |
+| cleanup.registry | string | `"docker.io"` | Cleanup-job image registry |
+| cleanup.repository | string | `"bitnami/kubectl"` | Cleanup-job image repository |
+| cleanup.tag | string | `"latest"` | Cleanup-job image tag (version) |
 | image.pullPolicy | string | `"IfNotPresent"` | Operator image pull policy |
 | image.registry | string | `"ghcr.io"` | Operator image registry |
 | image.repository | string | `"k8up-io/k8up"` | Operator image repository |

--- a/charts/k8up/templates/_helpers.tpl
+++ b/charts/k8up/templates/_helpers.tpl
@@ -80,3 +80,12 @@ Backup Image
 {{ if .k8up.backupImage.repository }}{{ .k8up.backupImage.repository }}{{ else }}{{ .image.registry}}/{{ .image.repository }}{{ end }}:{{ if .k8up.backupImage.tag }}{{ .k8up.backupImage.tag }}{{ else }}{{ .image.tag }}{{ end }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Cleanup Image
+*/}}
+{{- define "cleanupImage" -}}
+{{- with .Values -}}
+{{ if .cleanup.registry }}{{ .cleanup.registry }}/{{ end }}{{ .cleanup.repository }}:{{ .cleanup.tag }}
+{{- end -}}
+{{- end -}}

--- a/charts/k8up/templates/cleanup-hook.yaml
+++ b/charts/k8up/templates/cleanup-hook.yaml
@@ -83,7 +83,8 @@ spec:
       serviceAccountName: cleanup-service-account
       containers:
       - name: "{{ .Release.Name }}-cleanup"
-        image: "bitnami/kubectl:latest"
+        image: "{{ include "cleanupImage" . }}"
+        imagePullPolicy: {{ .Values.cleanup.pullPolicy }}
         command:
           - sh
           - -c

--- a/charts/k8up/values.yaml
+++ b/charts/k8up/values.yaml
@@ -132,3 +132,14 @@ resources:
     cpu: 20m
     # -- Memory request of K8up operator. See [supported units][resource-units].
     memory: 128Mi
+
+cleanup:
+  # -- Cleanup-job image pull policy
+  pullPolicy: IfNotPresent
+  # -- Cleanup-job image registry
+  registry: docker.io
+  # -- Cleanup-job image repository
+  repository: bitnami/kubectl
+  # -- Cleanup-job image tag (version)
+  tag: latest
+


### PR DESCRIPTION
## Summary

Adding new values to allow getting the cleanup image (bitnami/kubectl) from an internal registry.
Solves issue #889 

## Checklist

### For Helm Chart changes

- [x] Categorize the PR by setting a good title and adding one of the labels:
  `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
  as they show up in the changelog
- [x] PR contains the label `area:chart`
- [x] PR contains the chart label, e.g. `chart:k8up`
- [X] Variables are documented in the values.yaml using the format required by [Helm-Docs](https://github.com/norwoodj/helm-docs#valuesyaml-metadata).
- [X] Chart Version bumped if immediate release after merging is planned
- [x] I have run `make chart-docs`
- [ ] Link this PR to related code release or other issues.