### PR TITLE
Add backwards-compatibility for restore access key ID env

### DIFF
--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -47,7 +47,7 @@ var (
 			&cli.IntFlag{Destination: &cfg.Config.GlobalConcurrentPruneJobsLimit, Name: "global-concurrent-prune-jobs-limit", EnvVars: []string{"BACKUP_GLOBAL_CONCURRENT_PRUNE_JOBS_LIMIT"}, DefaultText: "unlimited", Usage: "set the limit of concurrent prune jobs"},
 			&cli.IntFlag{Destination: &cfg.Config.GlobalConcurrentRestoreJobsLimit, Name: "global-concurrent-restore-jobs-limit", EnvVars: []string{"BACKUP_GLOBAL_CONCURRENT_RESTORE_JOBS_LIMIT"}, DefaultText: "unlimited", Usage: "set the limit of concurrent restore jobs"},
 
-			&cli.StringFlag{Destination: &cfg.Config.GlobalRestoreS3AccessKey, Name: "globalrestores3accesskeyid", EnvVars: []string{"BACKUP_GLOBALRESTORES3ACCESKEYID"}, Usage: "set the global restore S3 accessKeyID for restores"},
+			&cli.StringFlag{Destination: &cfg.Config.GlobalRestoreS3AccessKey, Name: "globalrestores3accesskeyid", EnvVars: []string{"BACKUP_GLOBALRESTORES3ACCESKEYID", "BACKUP_GLOBALRESTORES3ACCESSKEYID"}, Usage: "set the global restore S3 accessKeyID for restores"},
 			&cli.StringFlag{Destination: &cfg.Config.GlobalRestoreS3Bucket, Name: "globalrestores3bucket", EnvVars: []string{"BACKUP_GLOBALRESTORES3BUCKET"}, Usage: "set the global restore S3 bucket for restores"},
 			&cli.StringFlag{Destination: &cfg.Config.GlobalRestoreS3Endpoint, Name: "globalrestores3endpoint", EnvVars: []string{"BACKUP_GLOBALRESTORES3ENDPOINT"}, Usage: "set the global restore S3 endpoint for the restores (needs the scheme 'http' or 'https')"},
 			&cli.StringFlag{Destination: &cfg.Config.GlobalRestoreS3SecretAccessKey, Name: "globalrestores3secretaccesskey", EnvVars: []string{"BACKUP_GLOBALRESTORES3SECRETACCESSKEY"}, Usage: "set the global restore S3 SecretAccessKey for restores"},

--- a/docs/modules/ROOT/examples/usage/operator.txt
+++ b/docs/modules/ROOT/examples/usage/operator.txt
@@ -18,7 +18,7 @@ OPTIONS:
    --global-concurrent-check-jobs-limit value          set the limit of concurrent check jobs (default: unlimited) [$BACKUP_GLOBAL_CONCURRENT_CHECK_JOBS_LIMIT]
    --global-concurrent-prune-jobs-limit value          set the limit of concurrent prune jobs (default: unlimited) [$BACKUP_GLOBAL_CONCURRENT_PRUNE_JOBS_LIMIT]
    --global-concurrent-restore-jobs-limit value        set the limit of concurrent restore jobs (default: unlimited) [$BACKUP_GLOBAL_CONCURRENT_RESTORE_JOBS_LIMIT]
-   --globalrestores3accesskeyid value                  set the global restore S3 accessKeyID for restores [$BACKUP_GLOBALRESTORES3ACCESKEYID]
+   --globalrestores3accesskeyid value                  set the global restore S3 accessKeyID for restores [$BACKUP_GLOBALRESTORES3ACCESKEYID] / [$BACKUP_GLOBALRESTORES3ACCESSKEYID]
    --globalrestores3bucket value                       set the global restore S3 bucket for restores [$BACKUP_GLOBALRESTORES3BUCKET]
    --globalrestores3endpoint value                     set the global restore S3 endpoint for the restores (needs the scheme 'http' or 'https') [$BACKUP_GLOBALRESTORES3ENDPOINT]
    --globalrestores3secretaccesskey value              set the global restore S3 SecretAccessKey for restores [$BACKUP_GLOBALRESTORES3SECRETACCESSKEY]


### PR DESCRIPTION
## Summary

In K8up v1 the env variable `BACKUP_GLOBALRESTORES3ACCESSKEYID` was
used and v2 introduced an unintended breaking change of this variable
to `BACKUP_GLOBALRESTORES3ACCESKEYID`.

Fixes #893

## Checklist

### For Code changes

- [ ] Categorize the PR by setting a good title and adding one of the labels:
  `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
  as they show up in the changelog
- [ ] PR contains the label `area:operator`
- [x] Link this PR to related issues
- [x] I have not made _any_ changes in the `charts/` directory.