### PR TITLE
Ignore commented-out targets in `make help`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ MAKEFLAGS += --no-builtin-variables
 
 .PHONY: help
 help: ## Show this help
-	@grep -E -h '\s##\s' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
+	@grep -E -h '^[^#].+\s##\s' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
 
 # extensible array of targets. Modules can add target to this variable for the all-in-one target.
 clean_targets := build-clean

--- a/envtest/integration.mk
+++ b/envtest/integration.mk
@@ -32,13 +32,6 @@ integration-test: $(setup_envtest_bin) generate restic-integration-test-setup .e
 	export KUBEBUILDER_ASSETS="$$($(setup_envtest_bin) $(ENVTEST_ADDITIONAL_FLAGS) use -i -p path '$(ENVTEST_K8S_VERSION)!')" && \
 	go test -tags=integration -coverprofile cover.out -covermode atomic ./...
 
-# .PHONY: integration-test
-# integration-test: $(setup_envtest_bin) .envtest_crds ## Run integration tests against code
-# 	$(setup_envtest_bin) $(ENVTEST_ADDITIONAL_FLAGS) use '$(ENVTEST_K8S_VERSION)!'
-# 	@chmod -R +w $(go_bin)/k8s
-# 	export KUBEBUILDER_ASSETS="$$($(setup_envtest_bin) $(ENVTEST_ADDITIONAL_FLAGS) use -i -p path '$(ENVTEST_K8S_VERSION)!')" && \
-# 	go test -tags=integration -coverprofile cover.out -covermode atomic ./...
-
 $(envtest_crd_dir):
 	@mkdir -p $@
 


### PR DESCRIPTION
## Summary

There's a target that is commented-out in `envtest/integration.mk` that
still shows up in the output of `make help`.

This commit filters out lines that start with a comment (`#`)

Plus I removed some commented-out code, because this is Git.

## Checklist

### For Code changes

- [x] Categorize the PR by setting a good title and adding one of the labels:
  `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
  as they show up in the changelog
- [x] PR contains the label `area:operator`
- [x] Link this PR to related issues
- [x] I have not made _any_ changes in the `charts/` directory.