### PR TITLE
Bug/fix restore single file backup command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ coverage/
 .cache
 _public/
 _archive/
+tmp/
 
 .github/release-notes.md
 

--- a/e2e/definitions/restore/restore-backupcommand.yaml
+++ b/e2e/definitions/restore/restore-backupcommand.yaml
@@ -1,0 +1,27 @@
+apiVersion: k8up.io/v1
+kind: Restore
+metadata:
+  name: k8up-restore-backupcommand
+  namespace: k8up-e2e-subject
+spec:
+  snapshot: $SNAPSHOT_ID
+  failedJobsHistoryLimit: 1
+  successfulJobsHistoryLimit: 1
+  restoreMethod:
+    folder:
+      claimName: subject-pvc
+  backend:
+    repoPasswordSecretRef:
+      name: backup-repo
+      key: password
+    s3:
+      endpoint: http://minio.minio.svc.cluster.local:9000
+      bucket: backup
+      accessKeyIDSecretRef:
+        name: backup-credentials
+        key: username
+      secretAccessKeySecretRef:
+        name: backup-credentials
+        key: password
+  podSecurityContext:
+    runAsUser: $ID

--- a/e2e/kind.mk
+++ b/e2e/kind.mk
@@ -29,7 +29,7 @@ $(KIND_KUBECONFIG): $(KIND)
 	# Applies local-path-config.yaml to kind cluster and forces restart of provisioner - can be simplified once https://github.com/kubernetes-sigs/kind/pull/3090 is merged.
 	# This is necessary due to the multi node cluster. Classic k8s hostPath provisioner doesn't permit multi node and sharedFileSystemPath support is only in local-path-provisioner v0.0.23.
 	@kubectl apply -n local-path-storage -f https://raw.githubusercontent.com/rancher/local-path-provisioner/v0.0.23/deploy/local-path-storage.yaml
-	@kubectl get cm -n local-path-storage local-path-config -o yaml|yq e '.data."config.json"="{\"nodePathMap\":[],\"sharedFileSystemPath\": \"/tmp/e2e/local-path-provisioner\"}"'|kubectl apply -f -
+	@kubectl get cm -n local-path-storage local-path-config -o yaml|yq $(yq --help | grep -q eval && echo e) '.data."config.json"="{\"nodePathMap\":[],\"sharedFileSystemPath\": \"/tmp/e2e/local-path-provisioner\"}"'|kubectl apply -f -
 	@kubectl delete po -n local-path-storage --all
 
 $(KIND): export GOBIN = $(go_bin)

--- a/e2e/test-08-restore-backupcommand.bats
+++ b/e2e/test-08-restore-backupcommand.bats
@@ -1,0 +1,47 @@
+#!/usr/bin/env bats
+
+load "lib/utils"
+load "lib/detik"
+load "lib/k8up"
+
+# shellcheck disable=SC2034
+DETIK_CLIENT_NAME="kubectl"
+# shellcheck disable=SC2034
+DETIK_CLIENT_NAMESPACE="k8up-e2e-subject"
+# shellcheck disable=SC2034
+DEBUG_DETIK="true"
+
+@test "Given a PVC, When creating a Backup of an annotated app, Then Restore stdout dump to PVC" {
+    expected_content="expected content: $(timestamp)"
+    expected_filename="expected_filename.txt"
+
+    given_a_running_operator
+    given_a_clean_ns
+    given_s3_storage
+    given_an_annotated_subject "${expected_filename}" "${expected_content}"
+
+    kubectl apply -f definitions/secrets
+    yq e '.spec.podSecurityContext.runAsUser='$(id -u)'' definitions/backup/backup.yaml | kubectl apply -f -
+
+    try "at most 10 times every 5s to get backup named 'k8up-backup' and verify that '.status.started' is 'true'"
+    verify_object_value_by_label job 'k8up.io/owned-by=backup_k8up-backup' '.status.active' 1 true
+
+    wait_until backup/k8up-backup completed
+
+    run restic snapshots
+
+    echo "---BEGIN restic snapshots output---"
+    echo "${output}" | jq .
+    echo "---END---"
+
+    echo -n "Number of Snapshots >= 1? "
+    jq -e 'length >= 1' <<< "${output}"          # Ensure that there was actually a backup created
+
+    run get_latest_snap_by_path /k8up-e2e-subject-subject-container.txt
+
+    yq e '.spec.snapshot="'${output}'" | .spec.podSecurityContext.runAsUser='$(id -u)'' definitions/restore/restore-backupcommand.yaml | kubectl apply -f -
+    wait_until restore/k8up-restore-backupcommand completed
+    verify "'.status.conditions[?(@.type==\"Completed\")].reason' is 'Succeeded' for Restore named 'k8up-restore-backupcommand'"
+
+    expect_file_in_container 'deploy/annotated-subject-deployment' 'subject-container' "/data/k8up-e2e-subject-subject-container.txt" "${expected_content}"
+}


### PR DESCRIPTION
## Summary

* This PR solves restoring a single snapshot file (when using `backupcommand` annotation). Issue: #803

I added a function to check if the snapshot contains one file, no need to create a folder and then symlinked this folder with a real restore path (In #803, when the restore snapshot makes panic because of the use of PVC path)

* Also I solved the problem in the make file when using another build of `yq` package (File: `e2e/kind.mk`)

## Checklist

### For Code changes

- [ ] Categorize the PR by setting a good title and adding one of the labels:
  `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
  as they show up in the changelog
- [ ] PR contains the label `area:operator`
- [x] Link this PR to related issues
- [x] I have not made _any_ changes in the `charts/` directory.


<!--
NOTE:
Do *not* mix code changes with chart changes, it will break the release process.
Delete the checklist section that doesn't apply to the change.

NOTE:
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
