### PR TITLE
Fix/kind pod backup with command

### DIFF
--- a/e2e/definitions/annotated-subject/pod.yaml
+++ b/e2e/definitions/annotated-subject/pod.yaml
@@ -1,0 +1,35 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: subject-pod
+  namespace: k8up-e2e-subject
+  annotations:
+    k8up.io/backupcommand: '/tmp/test.sh'
+    k8up.io/file-extension: '.txt'
+    k8up.io/backupcommand-container: subject-container
+spec:
+  containers:
+    - image: busybox
+      name: dummy-container-blocking-first-position
+      command:
+        - "/bin/sh"
+        - "-c"
+        - "sleep infinity"
+    - name: subject-container
+      image: quay.io/prometheus/busybox:latest
+      imagePullPolicy: IfNotPresent
+      args:
+        - sh
+        - -c
+        - |
+          printf '#!/bin/sh\nsleep 30s\necho %s\n' "$BACKUP_FILE_CONTENT" | tee /tmp/test.sh && chmod a+x /tmp/test.sh && \
+          echo && \
+          echo "sleeping now" && \
+          sleep infinity
+      securityContext:
+        runAsUser: $ID
+      env:
+        - name: BACKUP_FILE_CONTENT
+          value: ""
+        - name: BACKUP_FILE_NAME
+          value: ""

--- a/e2e/definitions/minio/helm.yaml
+++ b/e2e/definitions/minio/helm.yaml
@@ -1,6 +1,9 @@
-accessKey: myaccesskey
-secretKey: mysecretkey
+users:
+  - accessKey: myaccesskey
+    secretKey: mysecretkey
+    policy: consoleAdmin
 replicas: 1
+mode: standalone
 resources:
   requests:
     memory: 250M

--- a/e2e/lib/k8up.bash
+++ b/e2e/lib/k8up.bash
@@ -134,6 +134,17 @@ given_an_annotated_subject() {
 	echo "✅  The annotated subject is ready"
 }
 
+given_an_annotated_subject_pod() {
+  require_args 2 ${#}
+
+  export BACKUP_FILE_NAME=${1}
+  export BACKUP_FILE_CONTENT=${2}
+
+  yq e '.spec.containers[1].securityContext.runAsUser='$(id -u)' | .spec.containers[1].env[0].value=strenv(BACKUP_FILE_CONTENT) | .spec.containers[1].env[1].value=strenv(BACKUP_FILE_NAME)' definitions/annotated-subject/pod.yaml | kubectl apply -f -
+
+  echo "✅  The annotated subject pod is ready"
+}
+
 given_a_rwo_pvc_subject_in_worker_node() {
 	require_args 2 ${#}
 
@@ -159,7 +170,7 @@ given_a_rwo_pvc_subject_in_controlplane_node() {
 given_s3_storage() {
 	# Speed this step up
 	(helm -n "${MINIO_NAMESPACE}" list | grep minio > /dev/null) && return
-	helm repo add minio https://helm.min.io/ --force-update
+	helm repo add minio https://charts.min.io/ --force-update
 	helm repo update
 	helm upgrade --install minio \
 		--values definitions/minio/helm.yaml \

--- a/e2e/test-09-pod-backupcommand.bats
+++ b/e2e/test-09-pod-backupcommand.bats
@@ -1,0 +1,49 @@
+#!/usr/bin/env bats
+
+load "lib/utils"
+load "lib/detik"
+load "lib/k8up"
+
+# shellcheck disable=SC2034
+DETIK_CLIENT_NAME="kubectl"
+# shellcheck disable=SC2034
+DETIK_CLIENT_NAMESPACE="k8up-e2e-subject"
+# shellcheck disable=SC2034
+DEBUG_DETIK="true"
+
+@test "Creating a Backup of an annotated pod" {
+    expected_content="expected content: $(timestamp)"
+    expected_filename="expected_filename.txt"
+
+    given_a_running_operator
+    given_a_clean_ns
+    given_s3_storage
+    given_an_annotated_subject_pod "${expected_filename}" "${expected_content}"
+
+    kubectl apply -f definitions/secrets
+    yq e '.spec.podSecurityContext.runAsUser='$(id -u)'' definitions/backup/backup.yaml | kubectl apply -f -
+
+    try "at most 10 times every 5s to get backup named 'k8up-backup' and verify that '.status.started' is 'true'"
+    verify_object_value_by_label job 'k8up.io/owned-by=backup_k8up-backup' '.status.active' 1 true
+
+    wait_until backup/k8up-backup completed
+
+    run restic snapshots
+
+    echo "---BEGIN restic snapshots output---"
+    echo "${output}" | jq .
+    echo "---END---"
+
+    echo -n "Number of Snapshots >= 1? "
+    jq -e 'length >= 1' <<< "${output}"          # Ensure that there was actually a backup created
+
+    run get_latest_snap_by_path /k8up-e2e-subject-subject-container.txt
+
+    run restic dump --path /k8up-e2e-subject-subject-container.txt "${output}" k8up-e2e-subject-subject-container.txt
+
+    echo "---BEGIN actual /k8up-e2e-subject-subject-container.txt---"
+    echo "${output}"
+    echo "---END---"
+
+    [ "${output}" = "${expected_content}" ]
+}

--- a/restic/kubernetes/pod_list.go
+++ b/restic/kubernetes/pod_list.go
@@ -97,7 +97,12 @@ func (p *PodLister) ListPods() ([]BackupPod, error) {
 			fileExtension := annotations[p.fileExtensionAnnotation]
 
 			owner := pod.OwnerReferences
-			firstOwnerID := string(owner[0].UID)
+			var firstOwnerID string
+			if len(owner) > 0 {
+				firstOwnerID = string(owner[0].UID)
+			} else {
+				firstOwnerID = string(pod.ObjectMeta.UID)
+			}
 
 			if _, ok := sameOwner[firstOwnerID]; !ok {
 				sameOwner[firstOwnerID] = true


### PR DESCRIPTION
## Summary

* When creating API with pod kind in k8s, then can't make a backup with command because the pod doesn't have `OwnerReferences` and when the code gets a list of pods the code panicked

### Other changes

I added a test for checking to get a list of pods to make a backup.
Also, I found a problem in the helm chart of the minio, The URL `https://helm.min.io/` was not found and I changed it to `https://charts.min.io/`. The value of the chart has been changed and I have to change `e2e/definitions/minio/helm.yaml` according to these values.

## Checklist

### For Code changes

- [x] Categorize the PR by setting a good title and adding one of the labels:
  `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
  as they show up in the changelog
- [x] PR contains the label `area:operator`
- [x] Link this PR to related issues
- [x] I have not made _any_ changes in the `charts/` directory.

### For Helm Chart changes

- [ ] Categorize the PR by setting a good title and adding one of the labels:
  `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
  as they show up in the changelog
- [ ] PR contains the label `area:chart`
- [ ] PR contains the chart label, e.g. `chart:k8up`
- [ ] Variables are documented in the values.yaml using the format required by [Helm-Docs](https://github.com/norwoodj/helm-docs#valuesyaml-metadata).
- [ ] Chart Version bumped if immediate release after merging is planned
- [ ] I have run `make chart-docs`
- [ ] Link this PR to related code release or other issues.

<!--
NOTE:
Do *not* mix code changes with chart changes, it will break the release process.
Delete the checklist section that doesn't apply to the change.

NOTE:
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
