### PR TITLE
Add option to use a custom path inside an Azure Blob Storage Container

### DIFF
--- a/api/v1/backend.go
+++ b/api/v1/backend.go
@@ -204,6 +204,7 @@ func (in *GCSSpec) String() string {
 
 type AzureSpec struct {
 	Container            string                    `json:"container,omitempty"`
+	Path                 string                    `json:"path,omitempty"`
 	AccountNameSecretRef *corev1.SecretKeySelector `json:"accountNameSecretRef,omitempty"`
 	AccountKeySecretRef  *corev1.SecretKeySelector `json:"accountKeySecretRef,omitempty"`
 }
@@ -215,9 +216,14 @@ func (in *AzureSpec) EnvVars(vars map[string]*corev1.EnvVarSource) map[string]*c
 	return vars
 }
 
-// String returns "azure:container:/"
+// String returns "azure:container:path"
+// If Path is empty, the default value "/" will be used as path
 func (in *AzureSpec) String() string {
-	return fmt.Sprintf("azure:%s:/", in.Container)
+	path := "/"
+	if in.Path != "" {
+		path = in.Path
+	}
+	return fmt.Sprintf("azure:%s:%s", in.Container, path)
 }
 
 type SwiftSpec struct {

--- a/api/v1/backend_test.go
+++ b/api/v1/backend_test.go
@@ -28,6 +28,21 @@ var tests = map[string]struct {
 		},
 		expectedRepositoryString: "azure:container:/",
 	},
+	"GivenAzureBackendAndPath_ThenExpectAzureContainerWithCustomPath": {
+		givenBackend: &Backend{
+			Azure: &AzureSpec{
+				Container:            "container",
+				Path:                 "foo",
+				AccountNameSecretRef: newSecretRef("name"),
+				AccountKeySecretRef:  newSecretRef("key"),
+			},
+		},
+		expectedVars: map[string]*corev1.EnvVarSource{
+			cfg.AzureAccountEnvName:    {SecretKeyRef: newSecretRef("name")},
+			cfg.AzureAccountKeyEnvName: {SecretKeyRef: newSecretRef("key")},
+		},
+		expectedRepositoryString: "azure:container:foo",
+	},
 	"GivenB2Backend_ThenExpectB2BucketAndPath": {
 		givenBackend: &Backend{
 			B2: &B2Spec{

--- a/config/crd/apiextensions.k8s.io/v1/k8up.io_archives.yaml
+++ b/config/crd/apiextensions.k8s.io/v1/k8up.io_archives.yaml
@@ -100,6 +100,8 @@ spec:
                         x-kubernetes-map-type: atomic
                       container:
                         type: string
+                      path:
+                        type: string
                     type: object
                   b2:
                     properties:

--- a/config/crd/apiextensions.k8s.io/v1/k8up.io_backups.yaml
+++ b/config/crd/apiextensions.k8s.io/v1/k8up.io_backups.yaml
@@ -107,6 +107,8 @@ spec:
                         x-kubernetes-map-type: atomic
                       container:
                         type: string
+                      path:
+                        type: string
                     type: object
                   b2:
                     properties:

--- a/config/crd/apiextensions.k8s.io/v1/k8up.io_checks.yaml
+++ b/config/crd/apiextensions.k8s.io/v1/k8up.io_checks.yaml
@@ -101,6 +101,8 @@ spec:
                         x-kubernetes-map-type: atomic
                       container:
                         type: string
+                      path:
+                        type: string
                     type: object
                   b2:
                     properties:

--- a/config/crd/apiextensions.k8s.io/v1/k8up.io_prunes.yaml
+++ b/config/crd/apiextensions.k8s.io/v1/k8up.io_prunes.yaml
@@ -101,6 +101,8 @@ spec:
                         x-kubernetes-map-type: atomic
                       container:
                         type: string
+                      path:
+                        type: string
                     type: object
                   b2:
                     properties:

--- a/config/crd/apiextensions.k8s.io/v1/k8up.io_restores.yaml
+++ b/config/crd/apiextensions.k8s.io/v1/k8up.io_restores.yaml
@@ -101,6 +101,8 @@ spec:
                         x-kubernetes-map-type: atomic
                       container:
                         type: string
+                      path:
+                        type: string
                     type: object
                   b2:
                     properties:

--- a/config/crd/apiextensions.k8s.io/v1/k8up.io_schedules.yaml
+++ b/config/crd/apiextensions.k8s.io/v1/k8up.io_schedules.yaml
@@ -93,6 +93,8 @@ spec:
                             x-kubernetes-map-type: atomic
                           container:
                             type: string
+                          path:
+                            type: string
                         type: object
                       b2:
                         properties:
@@ -693,6 +695,8 @@ spec:
                         x-kubernetes-map-type: atomic
                       container:
                         type: string
+                      path:
+                        type: string
                     type: object
                   b2:
                     properties:
@@ -997,6 +1001,8 @@ spec:
                             type: object
                             x-kubernetes-map-type: atomic
                           container:
+                            type: string
+                          path:
                             type: string
                         type: object
                       b2:
@@ -1548,6 +1554,8 @@ spec:
                             type: object
                             x-kubernetes-map-type: atomic
                           container:
+                            type: string
+                          path:
                             type: string
                         type: object
                       b2:
@@ -2262,6 +2270,8 @@ spec:
                             x-kubernetes-map-type: atomic
                           container:
                             type: string
+                          path:
+                            type: string
                         type: object
                       b2:
                         properties:
@@ -2858,6 +2868,8 @@ spec:
                             type: object
                             x-kubernetes-map-type: atomic
                           container:
+                            type: string
+                          path:
                             type: string
                         type: object
                       b2:

--- a/docs/modules/ROOT/pages/references/object-specifications.adoc
+++ b/docs/modules/ROOT/pages/references/object-specifications.adoc
@@ -388,6 +388,7 @@ Settings:
 Settings:
 
 * `container`: name of the container that should be used
+* `path`: path inside the container, will default to "/" if omitted
 * `accountNameSecretRef`: Kubernetes secret reference containing the account name
 * `accountKeySecretRef`: Kubernetes secret reference containing the account key
 


### PR DESCRIPTION
## Summary

* Add optional Path field to CRD for the Azure backend
* Add a test
* Add documentation for the new field

## Checklist

### For Code changes

- [x] enhancement
- [x] PR contains the label `area:operator`
- [x] I have not made _any_ changes in the `charts/` directory.

<!--
NOTE:
Do *not* mix code changes with chart changes, it will break the release process.
Delete the checklist section that doesn't apply to the change.

NOTE:
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
