### PR TITLE
BUG: Set rest server credentials in repository URL

### DIFF
--- a/api/v1/backend.go
+++ b/api/v1/backend.go
@@ -3,6 +3,7 @@ package v1
 import (
 	"fmt"
 	"reflect"
+	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 
@@ -275,5 +276,6 @@ func (in *RestServerSpec) EnvVars(vars map[string]*corev1.EnvVarSource) map[stri
 
 // String returns "rest:URL"
 func (in *RestServerSpec) String() string {
-	return fmt.Sprintf("rest:%s", in.URL)
+	protocol, url, _ := strings.Cut(in.URL, "://")
+	return fmt.Sprintf("rest:%s://%s:%s@%s", protocol, "$(USER)", "$(PASSWORD)", url)
 }

--- a/api/v1/backend_test.go
+++ b/api/v1/backend_test.go
@@ -118,7 +118,7 @@ var tests = map[string]struct {
 			cfg.RestPasswordEnvName: {SecretKeyRef: newSecretRef("password")},
 			cfg.RestUserEnvName:     {SecretKeyRef: newSecretRef("user")},
 		},
-		expectedRepositoryString: "rest:https://server",
+		expectedRepositoryString: "rest:https://$(USER):$(PASSWORD)@server",
 	},
 }
 

--- a/operator/executor/envvarconverter.go
+++ b/operator/executor/envvarconverter.go
@@ -50,7 +50,10 @@ func (e *EnvVarConverter) setEntry(key string, value envVarEntry) {
 // are set the string will have precedence.
 func (e *EnvVarConverter) Convert() []corev1.EnvVar {
 	vars := make([]corev1.EnvVar, 0)
+	var repositoryVar corev1.EnvVar
+	var repositoryVarSet bool
 	for key, value := range e.Vars {
+
 		envVar := corev1.EnvVar{
 			Name: key,
 		}
@@ -59,7 +62,17 @@ func (e *EnvVarConverter) Convert() []corev1.EnvVar {
 		} else if value.stringEnv != nil {
 			envVar.Value = *value.stringEnv
 		}
-		vars = append(vars, envVar)
+		if key == cfg.ResticRepositoryEnvName {
+			// set repository env var at the end so the rest backend url
+			// can use previous set rest server credentials
+			repositoryVar = envVar
+			repositoryVarSet = true
+		} else {
+			vars = append(vars, envVar)
+		}
+	}
+	if repositoryVarSet {
+		vars = append(vars, repositoryVar)
 	}
 	return vars
 }


### PR DESCRIPTION
## Summary
Adds the rest server credentials to the repository env variable by using the previously set credential env vars. Therefore it was needed to ensure that the "RESTIC_REPOSITORY" var is set after all the others, cause a map isn't ordered.
This fixes #397.
## Checklist

### For Code changes

- [x] Categorize the PR by setting a good title and adding one of the labels:
  `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
  as they show up in the changelog
- [ ] PR contains the label `area:operator`
- [x] Link this PR to related issues
- [x] I have not made _any_ changes in the `charts/` directory.


<!--
NOTE:
Do *not* mix code changes with chart changes, it will break the release process.
Delete the checklist section that doesn't apply to the change.

NOTE:
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
