### PR TITLE
Update object-specifications.adoc to fix spelling mistake

### DIFF
--- a/docs/modules/ROOT/pages/references/object-specifications.adoc
+++ b/docs/modules/ROOT/pages/references/object-specifications.adoc
@@ -428,7 +428,7 @@ Settings:
 
 * `url`: URL of the Rest server instance (include scheme like `https://` on your own)
 * `userSecretRef`: Kubernetes secret reference containing the basic auth user
-* `passwordSecretReg`: Kubernetes secret reference containing the basic auth password
+* `passwordSecretRef`: Kubernetes secret reference containing the basic auth password
 
 == PreBackupPod
 


### PR DESCRIPTION
passwordSecretReg to passwordSecretRef

## Summary

Original documentation has a spelling mistake sercretPasswordReg

## Checklist
