### PR TITLE
Make e2e tests more reliable

### DIFF
--- a/e2e/lib/k8up.bash
+++ b/e2e/lib/k8up.bash
@@ -52,9 +52,12 @@ clear_pv_data() {
 	mkdir -p ./debug/data/pvc-subject
 }
 
+# We're not using `kubectl run --attach` here, to get the output of the pod.
+# It's very unreliable unfortunately. So running the pod, waiting and getting the
+# log output is a lot less prone for race conditions.
 restic() {
-	kubectl run "restic-$(timestamp)" \
-		--attach \
+	podname="restic-$(timestamp)"
+	kubectl run "$podname" \
 		--restart Never \
 		--namespace "${DETIK_CLIENT_NAMESPACE-"k8up-system"}" \
 		--image "${E2E_IMAGE}" \
@@ -68,7 +71,9 @@ restic() {
 		--no-cache \
 		--repo "s3:http://minio.minio.svc.cluster.local:9000/backup" \
 		"${@}" \
-		--json
+		--json > /dev/null
+	kubectl wait --for jsonpath='{.status.phase}'=Succeeded pod "$podname" -n "${DETIK_CLIENT_NAMESPACE-"k8up-system"}" --timeout=2m > /dev/null
+	kubectl -n "${DETIK_CLIENT_NAMESPACE-"k8up-system"}" logs "$podname"
 }
 
 replace_in_file() {


### PR DESCRIPTION
## Summary

`kubectl run --attach` proved to be rather unreliable. It often was not able to attach to the newly created pod. There were various different error messages.
    
By running the pod, waiting and then printing the logs, it improved the reliability by a lot. Where it previously failed ever so often, I was not able to have it fail once with the new function so far.

## Checklist

### For Code changes

- [x] Categorize the PR by setting a good title and adding one of the labels:
  `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
  as they show up in the changelog
- [x] PR contains the label `area:operator`
- [x] Link this PR to related issues
- [x] I have not made _any_ changes in the `charts/` directory.
