### PR TITLE
Helm chart: Adding cleanup.enabled and cleanup.imagePullSecrets

### DIFF
--- a/charts/k8up/templates/cleanup-hook.yaml
+++ b/charts/k8up/templates/cleanup-hook.yaml
@@ -1,3 +1,5 @@
+{{- if .Values.cleanup.enabled -}}
+
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -79,6 +81,10 @@ spec:
       labels:
         {{- include "k8up.selectorLabels" . | nindent 8 }}
     spec:
+    {{- with .Values.cleanup.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
       restartPolicy: Never
       serviceAccountName: cleanup-service-account
       containers:
@@ -99,3 +105,5 @@ spec:
               kubectl -n "$ns" delete rolebinding pod-executor-namespaced --ignore-not-found=true
               kubectl -n "$ns" delete role pod-executor --ignore-not-found=true
             done
+
+{{- end -}}

--- a/charts/k8up/values.yaml
+++ b/charts/k8up/values.yaml
@@ -141,6 +141,8 @@ resources:
     memory: 128Mi
 
 cleanup:
+  # -- Whether to enable cleanup of leftover rolebindings and roles from older k8up versions
+  enabled: false
   # -- Cleanup-job image pull policy
   pullPolicy: IfNotPresent
   # -- Cleanup-job image registry
@@ -149,3 +151,5 @@ cleanup:
   repository: bitnami/kubectl
   # -- Cleanup-job image tag (version)
   tag: latest
+  # -- Cleanup-job Image pull secrets to use 
+  imagePullSecrets: []


### PR DESCRIPTION
## Summary

This PR introduces two new settings to the k8up helm chart:
- cleanup.enabled:  Allows users to enable/disable the cleanup of leftover role bindings and roles from older K8up versions.
- cleanup.imagePullSecrets: This allows the cleanup job to pull images from private repositories. 

## Checklist

### For Helm Chart changes

- [ ] Categorize the PR by setting a good title and adding one of the labels:
  `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
  as they show up in the changelog
- [ ] PR contains the label `area:chart`
- [ ] PR contains the chart label, e.g. `chart:k8up`
- [ ] Variables are documented in the values.yaml using the format required by [Helm-Docs](https://github.com/norwoodj/helm-docs#valuesyaml-metadata).
- [ ] Chart Version bumped if immediate release after merging is planned
- [ ] I have run `make chart-docs`
- [ ] Link this PR to related code release or other issues.

