### PR TITLE
feat: add security context for cleanup hook

### DIFF
--- a/charts/k8up/Chart.yaml
+++ b/charts/k8up/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
   - backup
   - operator
   - restic
-version: 4.7.0
+version: 4.8.0
 sources:
   - https://github.com/k8up-io/k8up
 maintainers:

--- a/charts/k8up/README.md
+++ b/charts/k8up/README.md
@@ -1,6 +1,6 @@
 # k8up
 
-![Version: 4.7.0](https://img.shields.io/badge/Version-4.7.0-informational?style=flat-square)
+![Version: 4.8.0](https://img.shields.io/badge/Version-4.8.0-informational?style=flat-square)
 
 Kubernetes and OpenShift Backup Operator based on restic
 
@@ -13,7 +13,7 @@ helm repo add k8up-io https://k8up-io.github.io/k8up
 helm install k8up k8up-io/k8up
 ```
 ```bash
-kubectl apply -f https://github.com/k8up-io/k8up/releases/download/k8up-4.7.0/k8up-crd.yaml
+kubectl apply -f https://github.com/k8up-io/k8up/releases/download/k8up-4.8.0/k8up-crd.yaml
 ```
 
 <!---

--- a/charts/k8up/templates/cleanup-hook.yaml
+++ b/charts/k8up/templates/cleanup-hook.yaml
@@ -81,6 +81,8 @@ spec:
     spec:
       restartPolicy: Never
       serviceAccountName: cleanup-service-account
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
       - name: "{{ .Release.Name }}-cleanup"
         image: "{{ include "cleanupImage" . }}"
@@ -99,3 +101,5 @@ spec:
               kubectl -n "$ns" delete rolebinding pod-executor-namespaced --ignore-not-found=true
               kubectl -n "$ns" delete role pod-executor --ignore-not-found=true
             done
+        securityContext:
+          {{- toYaml .Values.securityContext | nindent 12 }}

--- a/charts/k8up/templates/grafana-dashboard.yaml
+++ b/charts/k8up/templates/grafana-dashboard.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: {{ default .Release.Namespace .Values.metrics.grafanaDashboard.namespace }}
   labels:
     {{- include "k8up.labels" . | nindent 4 }}
-    {{- with .Values.metrics.prometheusRule.additionalLabels }}
+    {{- with .Values.metrics.grafanaDashboard.additionalLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
 data:


### PR DESCRIPTION
## Summary

The operator deployment already supports setting `podSecurityContext` and `securityContext`. This PR allows setting both for the cleanup Job.

## Checklist

### For Helm Chart changes

- [x] Categorize the PR by setting a good title and adding one of the labels:
  `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
  as they show up in the changelog
- [x] PR contains the label `area:chart`
- [x] PR contains the chart label, e.g. `chart:k8up`
- [x] Variables are documented in the values.yaml using the format required by [Helm-Docs](https://github.com/norwoodj/helm-docs#valuesyaml-metadata).
- [x] Chart Version bumped if immediate release after merging is planned
- [x] I have run `make chart-docs`
- [ ] Link this PR to related code release or other issues.

<!--
NOTE:
Do *not* mix code changes with chart changes, it will break the release process.
Delete the checklist section that doesn't apply to the change.

NOTE:
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
