### PR TITLE
Adjust the PR template to include signing off the commits

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,6 +11,7 @@
   `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
   as they show up in the changelog
 - [ ] PR contains the label `area:operator`
+- [ ] Commits are [signed off](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
 - [ ] Link this PR to related issues
 - [ ] I have not made _any_ changes in the `charts/` directory.
 
@@ -21,6 +22,7 @@
   as they show up in the changelog
 - [ ] PR contains the label `area:chart`
 - [ ] PR contains the chart label, e.g. `chart:k8up`
+- [ ] Commits are [signed off](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
 - [ ] Variables are documented in the values.yaml using the format required by [Helm-Docs](https://github.com/norwoodj/helm-docs#valuesyaml-metadata).
 - [ ] Chart Version bumped if immediate release after merging is planned
 - [ ] I have run `make chart-docs`

--- a/deployment.yaml
+++ b/deployment.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-deployment
+  labels:
+    app: test-app
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: test-app
+  template:
+    metadata:
+      labels:
+        app: test-app
+    spec:
+      containers:
+        - name: test
+          image: busybox
+          command: ["sleep", "100000"]
+          volumeMounts:
+          - name: test
+            mountPath: /test
+      volumes:
+      - name: test
+        persistentVolumeClaim:
+          claimName: test-pvc


### PR DESCRIPTION
## Summary

* Adjust the PR template to include signing off the commits for the DCO

## Checklist

### For Code changes

- [x] Categorize the PR by setting a good title and adding one of the labels:
  `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
  as they show up in the changelog
- [x] PR contains the label `area:operator`
- [ ] Link this PR to related issues
- [x] I have not made _any_ changes in the `charts/` directory.

### For Helm Chart changes

- [ ] Categorize the PR by setting a good title and adding one of the labels:
  `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
  as they show up in the changelog
- [ ] PR contains the label `area:chart`
- [ ] PR contains the chart label, e.g. `chart:k8up`
- [ ] Variables are documented in the values.yaml using the format required by [Helm-Docs](https://github.com/norwoodj/helm-docs#valuesyaml-metadata).
- [ ] Chart Version bumped if immediate release after merging is planned
- [ ] I have run `make chart-docs`
- [ ] Link this PR to related code release or other issues.

<!--
NOTE:
Do *not* mix code changes with chart changes, it will break the release process.
Delete the checklist section that doesn't apply to the change.

NOTE:
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
