### PR TITLE
Ignore terminated Pods in mapping of PVCs to Pods

### DIFF
--- a/operator/backupcontroller/controller_integration_test.go
+++ b/operator/backupcontroller/controller_integration_test.go
@@ -312,7 +312,9 @@ func (ts *BackupTestSuite) Test_GivenBackupAndMountedRWOPVCOnOneNode_ExpectBacku
 
 	pvc1.Status.Phase = corev1.ClaimBound
 	pvc2.Status.Phase = corev1.ClaimBound
-	ts.UpdateStatus(pvc1, pvc2)
+	pod1.Status.Phase = corev1.PodRunning
+	pod2.Status.Phase = corev1.PodRunning
+	ts.UpdateStatus(pvc1, pvc2, pod1, pod2)
 
 	result := ts.whenReconciling(ts.BackupResource)
 	ts.Assert().GreaterOrEqual(result.RequeueAfter, 30*time.Second)
@@ -359,7 +361,9 @@ func (ts *BackupTestSuite) Test_GivenBackupAndMountedRWOPVCOnTwoNodes_ExpectBack
 
 	pvc1.Status.Phase = corev1.ClaimBound
 	pvc2.Status.Phase = corev1.ClaimBound
-	ts.UpdateStatus(pvc1, pvc2)
+	pod1.Status.Phase = corev1.PodRunning
+	pod2.Status.Phase = corev1.PodRunning
+	ts.UpdateStatus(pvc1, pvc2, pod1, pod2)
 
 	result := ts.whenReconciling(ts.BackupResource)
 	ts.Assert().GreaterOrEqual(result.RequeueAfter, 30*time.Second)
@@ -395,7 +399,9 @@ func (ts *BackupTestSuite) Test_GivenBackupAndMountedRWOPVCOnOneNodeWithFinished
 	ts.EnsureResources(ts.BackupResource, pvc1, pod1, pod2)
 
 	pvc1.Status.Phase = corev1.ClaimBound
-	ts.UpdateStatus(pvc1)
+	pod1.Status.Phase = corev1.PodRunning
+	pod2.Status.Phase = corev1.PodRunning
+	ts.UpdateStatus(pvc1, pod1, pod2)
 
 	result := ts.whenReconciling(ts.BackupResource)
 	ts.Assert().GreaterOrEqual(result.RequeueAfter, 30*time.Second)

--- a/operator/backupcontroller/controller_integration_test.go
+++ b/operator/backupcontroller/controller_integration_test.go
@@ -451,6 +451,35 @@ func (ts *BackupTestSuite) Test_GivenBackupAndUnmountedRWOPVCOnTwoNodes_ExpectBa
 	ts.assertJobSpecs(&job2, nodeNamePv2, []corev1.Volume{volumePvc2}, nil, []string{})
 }
 
+func (ts *BackupTestSuite) Test_GivenBackupAndRWOPVCWithFinishedPod_ExpectFinishedPodToBeIgnored() {
+	pvc1 := ts.newPvc("test-pvc1", corev1.ReadWriteOnce)
+	nodeNamePod1 := "worker"
+	nodeNamePod2 := "control-plane"
+	volumePvc1 := corev1.Volume{
+		Name: "test-pvc1",
+		VolumeSource: corev1.VolumeSource{
+			PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+				ClaimName: pvc1.Name,
+			},
+		},
+	}
+	tolerations := make([]corev1.Toleration, 0)
+	pod1 := ts.newPod("test-pod1", nodeNamePod1, tolerations, []corev1.Volume{volumePvc1})
+	pod2 := ts.newPod("test-pod2", nodeNamePod2, tolerations, []corev1.Volume{volumePvc1})
+
+	ts.EnsureResources(ts.BackupResource, pvc1, pod1, pod2)
+
+	pvc1.Status.Phase = corev1.ClaimBound
+	pod1.Status.Phase = corev1.PodRunning
+	pod2.Status.Phase = corev1.PodSucceeded
+	ts.UpdateStatus(pvc1, pod1, pod2)
+
+	ts.whenReconciling(ts.BackupResource)
+	job := ts.expectABackupJob()
+
+	ts.assertJobSpecs(job, nodeNamePod1, []corev1.Volume{volumePvc1}, tolerations, []string{pod1.Name})
+}
+
 func (ts *BackupTestSuite) assertCondition(conditions []metav1.Condition, condType k8upv1.ConditionType, reason k8upv1.ConditionReason, status metav1.ConditionStatus) {
 	cond := meta.FindStatusCondition(conditions, condType.String())
 	ts.Require().NotNil(cond, "condition of type %s missing", condType)

--- a/operator/backupcontroller/executor.go
+++ b/operator/backupcontroller/executor.go
@@ -69,8 +69,8 @@ func (b *BackupExecutor) listAndFilterPVCs(ctx context.Context, annotation strin
 		return nil, fmt.Errorf("list pods: %w", err)
 	}
 	for _, pod := range pods.Items {
-		if pod.Status.Phase == corev1.PodSucceeded || pod.Status.Phase == corev1.PodFailed {
-			log.V(1).Info("Ignoring terminated Pod", "pod", pod.GetName())
+		if pod.Status.Phase != corev1.PodRunning {
+			log.V(1).Info("Ignoring Pod which is not running", "pod", pod.GetName())
 			continue
 		}
 		for _, volume := range pod.Spec.Volumes {

--- a/operator/backupcontroller/executor.go
+++ b/operator/backupcontroller/executor.go
@@ -69,6 +69,10 @@ func (b *BackupExecutor) listAndFilterPVCs(ctx context.Context, annotation strin
 		return nil, fmt.Errorf("list pods: %w", err)
 	}
 	for _, pod := range pods.Items {
+		if pod.Status.Phase == corev1.PodSucceeded || pod.Status.Phase == corev1.PodFailed {
+			log.V(1).Info("Ignoring terminated Pod", "pod", pod.GetName())
+			continue
+		}
 		for _, volume := range pod.Spec.Volumes {
 			if volume.PersistentVolumeClaim != nil {
 				pvcPodMap[volume.PersistentVolumeClaim.ClaimName] = pod


### PR DESCRIPTION
## Summary

Think that terminated Pods should be ignored when building the mapping from PVC to Pod.

Issue: https://github.com/k8up-io/k8up/issues/978

## Checklist

### For Code changes

- [x] Categorize the PR by setting a good title and adding one of the labels:
  `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
  as they show up in the changelog
- [x] PR contains the label `area:operator`
- [x] Commits are [signed off](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
- [x] Link this PR to related issues
- [x] I have not made _any_ changes in the `charts/` directory.

### For Helm Chart changes

- [ ] Categorize the PR by setting a good title and adding one of the labels:
  `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
  as they show up in the changelog
- [ ] PR contains the label `area:chart`
- [ ] PR contains the chart label, e.g. `chart:k8up`
- [ ] Commits are [signed off](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
- [ ] Variables are documented in the values.yaml using the format required by [Helm-Docs](https://github.com/norwoodj/helm-docs#valuesyaml-metadata).
- [ ] Chart Version bumped if immediate release after merging is planned
- [ ] I have run `make chart-docs`
- [ ] Link this PR to related code release or other issues.

<!--
NOTE:
Do *not* mix code changes with chart changes, it will break the release process.
Delete the checklist section that doesn't apply to the change.

NOTE:
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
