### PR TITLE
Unmounted RWO PVCs without NodeAffinity on the PV should be backed up as well

### DIFF
--- a/operator/backupcontroller/executor.go
+++ b/operator/backupcontroller/executor.go
@@ -91,7 +91,7 @@ func (b *BackupExecutor) listAndFilterPVCs(ctx context.Context, annotation strin
 
 	for _, pvc := range claimlist.Items {
 		if pvc.Status.Phase != corev1.ClaimBound {
-			log.Info("PVC is not bound", "pvc", pvc.GetName())
+			log.Info("PVC is not bound, skipping PVC", "pvc", pvc.GetName())
 			continue
 		}
 
@@ -99,7 +99,7 @@ func (b *BackupExecutor) listAndFilterPVCs(ctx context.Context, annotation strin
 
 		isRWO := containsAccessMode(pvc.Spec.AccessModes, corev1.ReadWriteOnce)
 		if !containsAccessMode(pvc.Spec.AccessModes, corev1.ReadWriteMany) && !isRWO && !hasBackupAnnotation {
-			log.Info("PVC is neither RWX nor RWO and has no backup annotation", "pvc", pvc.GetName())
+			log.Info("PVC is neither RWX nor RWO and has no backup annotation, skipping PVC", "pvc", pvc.GetName())
 			continue
 		}
 

--- a/operator/backupcontroller/executor.go
+++ b/operator/backupcontroller/executor.go
@@ -143,8 +143,7 @@ func (b *BackupExecutor) listAndFilterPVCs(ctx context.Context, annotation strin
 
 			bi.node = findNode(pv, pvc)
 			if bi.node == "" {
-				log.Info("RWO PVC not bound and no PV node affinity set, skipping", "pvc", pvc.GetName(), "affinity", pv.Spec.NodeAffinity)
-				continue
+				log.Info("RWO PVC not bound and no PV node affinity set, adding", "pvc", pvc.GetName(), "affinity", pv.Spec.NodeAffinity)
 			}
 			log.V(1).Info("node found in PV or PVC", "pvc", pvc.GetName(), "node", bi.node)
 		} else {


### PR DESCRIPTION
## Summary

I did realize that k8up was skipping one of my volumes because it was not bound and had no NodeAffinity on its PVC. I believe this is wrong behavior, since RWO Volumes without NodeAffinity can be used on any Node. In my case I have RWO PVCs based on Rook Ceph, they have RWO semantics but have no restriction on the Node.

This change adds an integration test which describes the expected behavior and changes the code so that these volumes are included.

## Checklist

### For Code changes

- [x] Categorize the PR by setting a good title and adding one of the labels:
  `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
  as they show up in the changelog
- [x] PR contains the label `area:operator`
- [x] Commits are [signed off](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
- [ ] Link this PR to related issues
- [x] I have not made _any_ changes in the `charts/` directory.

### For Helm Chart changes

- [ ] Categorize the PR by setting a good title and adding one of the labels:
  `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
  as they show up in the changelog
- [ ] PR contains the label `area:chart`
- [ ] PR contains the chart label, e.g. `chart:k8up`
- [ ] Commits are [signed off](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
- [ ] Variables are documented in the values.yaml using the format required by [Helm-Docs](https://github.com/norwoodj/helm-docs#valuesyaml-metadata).
- [ ] Chart Version bumped if immediate release after merging is planned
- [ ] I have run `make chart-docs`
- [ ] Link this PR to related code release or other issues.

<!--
NOTE:
Do *not* mix code changes with chart changes, it will break the release process.
Delete the checklist section that doesn't apply to the change.

NOTE:
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
