### PR TITLE
Properly set logger before creating a typed client

### DIFF
--- a/cmd/restic/main.go
+++ b/cmd/restic/main.go
@@ -283,7 +283,7 @@ func backupAnnotatedPods(ctx context.Context, resticCLI *resticCli.Restic, mainL
 		return nil
 	}
 
-	k8cli, err := kubernetes.NewTypedClient()
+	k8cli, err := kubernetes.NewTypedClient(mainLogger)
 	if err != nil {
 		return fmt.Errorf("Could not create kubernetes client: %w", err)
 	}

--- a/restic/cli/backup.go
+++ b/restic/cli/backup.go
@@ -113,7 +113,7 @@ func (r *Restic) sendSnapshotList() {
 		r.logger.Error(err, "webhook send failed")
 	}
 
-	err = kubernetes.SyncSnapshotList(r.ctx, r.snapshots, cfg.Config.Hostname, cfg.Config.ResticRepository)
+	err = kubernetes.SyncSnapshotList(r.ctx, r.snapshots, cfg.Config.Hostname, cfg.Config.ResticRepository, r.logger)
 	if err != nil {
 		r.logger.Error(err, "cannot sync snapshots to the cluster")
 	}

--- a/restic/kubernetes/config.go
+++ b/restic/kubernetes/config.go
@@ -7,7 +7,9 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 
+	"github.com/go-logr/logr"
 	k8upv1 "github.com/k8up-io/k8up/v2/api/v1"
 	"github.com/k8up-io/k8up/v2/restic/cfg"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -28,7 +30,10 @@ func getClientConfig() (*rest.Config, error) {
 	return config, nil
 }
 
-func NewTypedClient() (client.Client, error) {
+func NewTypedClient(l logr.Logger) (client.Client, error) {
+
+	log.SetLogger(l)
+
 	scheme := runtime.NewScheme()
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 	utilruntime.Must(k8upv1.AddToScheme(scheme))

--- a/restic/kubernetes/snapshots.go
+++ b/restic/kubernetes/snapshots.go
@@ -3,6 +3,7 @@ package kubernetes
 import (
 	"context"
 
+	"github.com/go-logr/logr"
 	k8upv1 "github.com/k8up-io/k8up/v2/api/v1"
 	"github.com/k8up-io/k8up/v2/restic/dto"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -11,12 +12,12 @@ import (
 
 // SyncSnapshotList will take a k8upv1.SnapshotList and apply them to the k8s cluster.
 // It will remove any snapshots on the cluster that are not present in the list.
-func SyncSnapshotList(ctx context.Context, list []dto.Snapshot, namespace, repository string) error {
+func SyncSnapshotList(ctx context.Context, list []dto.Snapshot, namespace, repository string, l logr.Logger) error {
 
 	newList := filterAndConvert(list, namespace, repository)
 	oldList := &k8upv1.SnapshotList{}
 
-	kube, err := NewTypedClient()
+	kube, err := NewTypedClient(l)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION

## Summary

During pre-backup operations it was possible that the typed client was initialized without setting the logger first. Which lead to a big, but harmless, stacktrace in the backup pods.

This commit makes sure that the logger will be set every time the client gets created.

Resolves: #981

## Checklist

### For Code changes

- [x] Categorize the PR by setting a good title and adding one of the labels:
  `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
  as they show up in the changelog
- [x] PR contains the label `area:operator`
- [x] Commits are [signed off](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
- [x] Link this PR to related issues
- [x] I have not made _any_ changes in the `charts/` directory.

<!--
NOTE:
Do *not* mix code changes with chart changes, it will break the release process.
Delete the checklist section that doesn't apply to the change.

NOTE:
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
