### PR TITLE
fix(chart:k8up): Rename & implement grafanaDashboard.enabled

### DIFF
--- a/charts/k8up/Chart.yaml
+++ b/charts/k8up/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
   - backup
   - operator
   - restic
-version: 4.8.0
+version: 4.8.1
 sources:
   - https://github.com/k8up-io/k8up
 maintainers:

--- a/charts/k8up/README.md
+++ b/charts/k8up/README.md
@@ -1,6 +1,6 @@
 # k8up
 
-![Version: 4.8.0](https://img.shields.io/badge/Version-4.8.0-informational?style=flat-square)
+![Version: 4.8.1](https://img.shields.io/badge/Version-4.8.1-informational?style=flat-square)
 
 Kubernetes and OpenShift Backup Operator based on restic
 
@@ -13,7 +13,7 @@ helm repo add k8up-io https://k8up-io.github.io/k8up
 helm install k8up k8up-io/k8up
 ```
 ```bash
-kubectl apply -f https://github.com/k8up-io/k8up/releases/download/k8up-4.8.0/k8up-crd.yaml --server-side
+kubectl apply -f https://github.com/k8up-io/k8up/releases/download/k8up-4.8.1/k8up-crd.yaml --server-side
 ```
 
 <!---
@@ -63,7 +63,7 @@ Document your changes in values.yaml and let `make docs:helm` generate this sect
 | k8up.skipWithoutAnnotation | bool | `false` | Specifies whether K8up should ignore PVCs without the backup annotation (by default, `k8up.io/backup`) |
 | k8up.timezone | string | `""` | Specifies the timezone K8up is using for scheduling. Empty value defaults to the timezone in which Kubernetes is deployed. Accepts `tz database` compatible entries, e.g. `Europe/Zurich` |
 | metrics.grafanaDashboard.additionalLabels | object | `{}` | Add labels to the Grafana Dashboard object |
-| metrics.grafanaDashboard.enable | bool | `false` | Whether to deploy the Grafana dashboard |
+| metrics.grafanaDashboard.enabled | bool | `false` | Whether to deploy the Grafana dashboard |
 | metrics.grafanaDashboard.namespace | string | `""` | If the object should be installed in a different namespace than operator |
 | metrics.prometheusRule.additionalLabels | object | `{}` | Add labels to the PrometheusRule object |
 | metrics.prometheusRule.additionalRules | list | `[]` | Provide additional alert rules in addition to the defaults |

--- a/charts/k8up/templates/grafana-dashboard.yaml
+++ b/charts/k8up/templates/grafana-dashboard.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.metrics.grafanaDashboard.enabled -}}
 kind: ConfigMap
 apiVersion: v1
 metadata:
@@ -1204,3 +1205,4 @@ data:
       "weekStart": ""
     }
     `}}
+{{- end -}}

--- a/charts/k8up/values.yaml
+++ b/charts/k8up/values.yaml
@@ -129,7 +129,7 @@ metrics:
     additionalRules: []
   grafanaDashboard:
     # -- Whether to deploy the Grafana dashboard
-    enable: false
+    enabled: false
     # -- If the object should be installed in a different namespace than operator
     namespace: ""
     # -- Add labels to the Grafana Dashboard object


### PR DESCRIPTION
## Summary

Previously, the value was never checked and the ConfigMap was always created. Also rename the parameter to be in line with the other metrics values.

## Checklist

### For Helm Chart changes

- [x] Categorize the PR by setting a good title and adding one of the labels:
  `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
  as they show up in the changelog
- [x] PR contains the label `area:chart`
- [x] PR contains the chart label, e.g. `chart:k8up`
- [x] Commits are [signed off](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
- [x] Variables are documented in the values.yaml using the format required by [Helm-Docs](https://github.com/norwoodj/helm-docs#valuesyaml-metadata).
- [x] Chart Version bumped if immediate release after merging is planned
- [x] I have run `make chart-docs`
- [ ] Link this PR to related code release or other issues.

<!--
NOTE:
Do *not* mix code changes with chart changes, it will break the release process.
Delete the checklist section that doesn't apply to the change.

NOTE:
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
