### PR TITLE
fix(restic): Don't set `--options` if there are none

### DIFF
--- a/restic/cli/restic.go
+++ b/restic/cli/restic.go
@@ -57,8 +57,8 @@ type clientCert struct {
 func New(ctx context.Context, logger logr.Logger, statsHandler StatsHandler) *Restic {
 	globalFlags := Flags{}
 
-	options := strings.Split(cfg.Config.ResticOptions, ",")
-	if len(options) > 0 {
+	if cfg.Config.ResticOptions != "" {
+		options := strings.Split(cfg.Config.ResticOptions, ",")
 		logger.Info("using the following restic options", "options", options)
 		globalFlags.AddFlag("--option", options...)
 	}


### PR DESCRIPTION
Calling `strings.Split` on an empty string still returns a slice with one empty string in it, hence setting `options`.

This commit changes the implementation to _first_ check for empty strings, before even calling `strings.Split`.

## Checklist

### For Code changes

- [ ] Categorize the PR by setting a good title and adding one of the labels:
  `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
  as they show up in the changelog
- [ ] PR contains the label `area:operator`
- [x] Commits are [signed off](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
- [x] Link this PR to related issues
- [x] I have not made _any_ changes in the `charts/` directory.