### PR TITLE
pin the example mariadb prebackuppod image to a working one

### DIFF
--- a/docs/modules/ROOT/pages/how-tos/prebackuppod.adoc
+++ b/docs/modules/ROOT/pages/how-tos/prebackuppod.adoc
@@ -28,7 +28,7 @@ spec:
               value: topsecret
             - name: DB_HOST
               value: mariadb.example.com
-          image: mariadb
+          image: mariadb:10.4
           command:
             - 'sleep'
             - 'infinity'


### PR DESCRIPTION
## Summary

The current how-to is broken - the latest tag doesn't contain mysqldump. This matches it with the example found in the tutorial, which does have that available