### PR TITLE
Update CRD installation for tutorial

### DIFF
--- a/docs/modules/ROOT/pages/tutorials/tutorial.adoc
+++ b/docs/modules/ROOT/pages/tutorials/tutorial.adoc
@@ -75,10 +75,10 @@ IMPORTANT: On some laptops, running Minikube on battery power severely undermine
 
 . Install the CRDs K8up uses:
 ifeval::["{page-component-version}" == "master"]
-* `kubectl apply -f \https://github.com/k8up-io/k8up/releases/download/v{page-component-latest-version}.0/k8up-crd.yaml`
+* `kubectl apply -f \https://github.com/k8up-io/k8up/releases/download/v{page-component-latest-version}.0/k8up-crd.yaml` --server-side
 endif::[]
 ifeval::["{page-component-version}" != "master"]
-* `kubectl apply -f \https://github.com/k8up-io/k8up/releases/download/{releaseVersion}/k8up-crd.yaml`
+* `kubectl apply -f \https://github.com/k8up-io/k8up/releases/download/{releaseVersion}/k8up-crd.yaml` --server-side
 endif::[]
 
 . Install K8up in Minikube:


### PR DESCRIPTION
## Summary

Similar to #977, the installation fails on the client side. Aligned with charts/k8up/README.md to suggest server side apply as well. Prevents an error message "metadata.annotations: Too long: must have at most 262144 bytes" for later CRD resources during installation.

## Checklist

### For Code changes

- [ ] Categorize the PR by setting a good title and adding one of the labels:
  `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
  as they show up in the changelog
- [ ] PR contains the label `area:operator`
- [x] Commits are [signed off](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
- [x] Link this PR to related issues
- [x] I have not made _any_ changes in the `charts/` directory.
