### PR TITLE
Clarify which `yq` to use for end-to-end tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ To run the end-to-end test (e.g. `make e2e-test`), you additionally need:
 
 - `helm` (version 3)
 - `jq`
-- `yq`
+- `yq` (make sure to use [mikefarah/yq](https://github.com/mikefarah/yq) and not [kislyuk/yq](https://github.com/kislyuk/yq))
 - `node` and `npm`
 - `bash` (installed, doesn't have to be your default shell)
 - `base64`


### PR DESCRIPTION


## Summary

There are two projects with the name "yq" and it's easy to confuse them. Document which project to use as they are not interchangeable and e2e-tests do not work if the wrong project is installed.

I just spent a few hours trying to debug and fix E2E tests because I couldn't work out how they were failing until I realised that the version installed in https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md (the runner used for the - clearly working - e2e-tests) is `4.45.1` but https://github.com/kislyuk/yq latest release is `3.4.3` and both Arch and Ubuntu install that package by default. On the other hand https://github.com/mikefarah/yq is a [totally different package](https://github.com/Homebrew/homebrew-core/issues/29529). Once I swapped out the packages, the issue went away.

This PR just makes it clear which one is needed so that you can run those tests locally.

## Checklist

### For Code changes

- [ ] Categorize the PR by setting a good title and adding one of the labels:
  `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
  as they show up in the changelog
- [ ] PR contains the label `area:operator`
- [x] Commits are [signed off](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
- [ ] Link this PR to related issues
- [x] I have not made _any_ changes in the `charts/` directory.
<!--
NOTE:
Do *not* mix code changes with chart changes, it will break the release process.
Delete the checklist section that doesn't apply to the change.

NOTE:
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
