### PR TITLE
Fix for restic progress fps

### DIFF
--- a/docs/modules/ROOT/examples/usage/operator.txt
+++ b/docs/modules/ROOT/examples/usage/operator.txt
@@ -40,6 +40,7 @@ OPTIONS:
    --globalstatsurl value                              set the URL to post metrics globally [$BACKUP_GLOBALSTATSURL]
    --metrics-bindaddress value                         set the bind address for the prometheus endpoint (default: ":8080") [$BACKUP_METRICS_BINDADDRESS]
    --promurl value                                     set the operator wide default prometheus push gateway (default: "http://127.0.0.1/") [$BACKUP_PROMURL]
+   --clusterName value                                 set the operator wide kubernetes cluster name to send to push gateway for grouping metrics (default: "default") [$CLUSTER_NAME]
    --restartpolicy value                               set the RestartPolicy for the backup jobs. According to https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/, this should be 'OnFailure' for jobs that terminate (default: "OnFailure") [$BACKUP_RESTARTPOLICY]
    --podfilter value                                   the filter used to find the backup pods (default: "backupPod=true") [$BACKUP_PODFILTER]
    --podexecaccountname value, --serviceaccount value  set the service account name that should be used for the pod command execution (default: "pod-executor") [$BACKUP_PODEXECACCOUNTNAME]

--- a/docs/modules/ROOT/examples/usage/restic.txt
+++ b/docs/modules/ROOT/examples/usage/restic.txt
@@ -18,6 +18,7 @@ OPTIONS:
    --backucontainerannotation value                                               set the annotation name that specify the backup container inside the Pod (default: "k8up.io/backupcommand-container") [$BACKUP_CONTAINERANNOTATION]
    --skipPreBackup                                                                If the job should skip the backup command and only backup volumes. (default: false) [$SKIP_PREBACKUP]
    --promURL value                                                                Sets the URL of a prometheus push gateway to report metrics. [$PROM_URL]
+   --clusterName value                                                            Sets the Kubernetes cluster name for grouping metrics in push gateway [$CLUSTER_NAME]
    --webhookURL value, --statsURL value                                           Sets the URL of a server which will retrieve a webhook after the action completes. [$STATS_URL]
    --backupDir value                                                              Set from which directory the backup should be performed. (default: "/data") [$BACKUP_DIR]
    --restoreDir value                                                             Set to which directory the restore should be performed. (default: "/data") [$RESTORE_DIR]

--- a/operator/backupcontroller/backup_utils.go
+++ b/operator/backupcontroller/backup_utils.go
@@ -89,9 +89,6 @@ func (b *BackupExecutor) createServiceAccountAndBinding(ctx context.Context) err
 		return err
 	}
 
-	if err != nil {
-		return err
-	}
 	roleBinding := &rbacv1.RoleBinding{}
 	roleBinding.Name = cfg.Config.PodExecRoleName + "-namespaced"
 	roleBinding.Namespace = b.backup.Namespace

--- a/operator/backupcontroller/executor.go
+++ b/operator/backupcontroller/executor.go
@@ -231,10 +231,6 @@ func (b *BackupExecutor) startBackup(ctx context.Context) error {
 		backupJobs[jobName] = j
 	}
 
-	if err != nil {
-		return err
-	}
-
 	log := controllerruntime.LoggerFrom(ctx)
 	podLister := kubernetes.NewPodLister(ctx, b.Client, cfg.Config.BackupCommandAnnotation, "", "", b.backup.Namespace, nil, false, log)
 	backupPods, err := podLister.ListPods()

--- a/restic/cli/command.go
+++ b/restic/cli/command.go
@@ -74,7 +74,7 @@ func (c *Command) Configure() {
 
 func (c *Command) setResticProgressFPSIfNotDefined(givenEnv []string) []string {
 	for _, envVar := range givenEnv {
-		if strings.HasPrefix("RESTIC_PROGRESS_FPS=", envVar) {
+		if strings.HasPrefix(envVar, "RESTIC_PROGRESS_FPS=") {
 			return givenEnv
 		}
 	}


### PR DESCRIPTION
## Summary

* Fixes issue with being able to specify "RESTIC_PROGRESS_FPS" as defined in issue #1047 
* Clean up use of unused error checks.

## Checklist

### For Code changes

- [x] Categorize the PR by setting a good title and adding one of the labels:
  `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
  as they show up in the changelog
- [x] PR contains the label `area:operator`
- [x] Commits are [signed off](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
- [x] Link this PR to related issues
- [x] I have not made _any_ changes in the `charts/` directory.



<!--
NOTE:
Do *not* mix code changes with chart changes, it will break the release process.
Delete the checklist section that doesn't apply to the change.

NOTE:
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
