### PR TITLE
[bug] use new k8up job label in prometheus rule

### DIFF
--- a/charts/k8up/templates/prometheus/prometheusrule.yaml
+++ b/charts/k8up/templates/prometheus/prometheusrule.yaml
@@ -33,12 +33,12 @@ spec:
             runbook_url: https://k8up.io/k8up/explanations/runbooks/K8upBackupNotRunning.html
         {{- range .Values.metrics.prometheusRule.jobFailedRulesFor }}
         - alert: K8up{{- . | title -}}Failed
-          expr: (sum(kube_job_status_failed) by(job_name, namespace) * on(job_name, namespace) group_right() kube_job_labels{label_k8up_syn_tools_type="{{- . -}}"}) > 0
+          expr: (sum(kube_job_status_failed) by(job_name, namespace) * on(job_name, namespace) group_right() kube_job_labels{label_k8up_io_type="{{- . -}}"}) > 0
           for: 1m
           labels:
             severity: critical
           annotations:
-            summary: "Job in {{ "{{ $labels.namespace }}" }} of type {{ "{{ $labels.label_k8up_syn_tools_type }}" }} failed"
+            summary: "Job in {{ "{{ $labels.namespace }}" }} of type {{ "{{ $labels.label_k8up_io_type }}" }} failed"
             runbook_url: https://k8up.io/k8up/explanations/runbooks/K8up{{- . | title -}}Failed.html
         {{- end }}
         {{- end }}


### PR DESCRIPTION
## Summary

* Short summary of what's included in the PR
* Give special note to breaking changes: List the exact changes or provide links to documentation.

## Checklist

### For Code changes

- [ ] Categorize the PR by setting a good title and adding one of the labels:
  `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
  as they show up in the changelog
- [ ] PR contains the label `area:operator`
- [ ] Commits are [signed off](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
- [ ] Link this PR to related issues
- [ ] I have not made _any_ changes in the `charts/` directory.

### For Helm Chart changes

- [X] Categorize the PR by setting a good title and adding one of the labels:
  `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
  as they show up in the changelog
- [x] PR contains the label `area:chart`
- [x] PR contains the chart label, e.g. `chart:k8up`
- [X] Commits are [signed off](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
- [X] Variables are documented in the values.yaml using the format required by [Helm-Docs](https://github.com/norwoodj/helm-docs#valuesyaml-metadata).
- [ ] Chart Version bumped if immediate release after merging is planned
- [X] I have run `make chart-docs`
- [X] Link this PR to related code release or other issues.

It fixes this issue: https://github.com/k8up-io/k8up/issues/1058

<!--
NOTE:
Do *not* mix code changes with chart changes, it will break the release process.
Delete the checklist section that doesn't apply to the change.

NOTE:
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
