### PR TITLE
Add Information about backing up now

### DIFF
--- a/docs/modules/ROOT/pages/how-tos/backup.adoc
+++ b/docs/modules/ROOT/pages/how-tos/backup.adoc
@@ -11,6 +11,8 @@ Save the YAML above in a file named `backup.yaml` and use the `kubectl apply -f 
 
 TIP: To have backups run automatically at a regular interval look at xref:how-tos/schedules.adoc[schedules].
 
+TIP: Deploying this configuration also creates a Backup of the current state and does not wait until the xref:how-tos/schedules.adoc[schedules] are run.
+
 TIP: By default, all PVCs are backed up automatically. Adding the annotation `k8up.io/backup=false` to a PVC object will exclude it from all following backups. Alternatively, you can set the environment variable `BACKUP_SKIP_WITHOUT_ANNOTATION=true` if you want K8up to ignore objects without the annotation.
 
 == Self-signed issuer and Mutual TLS


### PR DESCRIPTION
## Summary

* Add tip for running a backup immediately whithout haveing to wait for a schedule to trigger in the documentation

## Checklist

### For Code changes

- [x] Categorize the PR by setting a good title and adding one of the labels:
  `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
  as they show up in the changelog
- [x] PR contains the label `area:operator`
- [x] Commits are [signed off](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
- [x] Link this PR to related issues
- [x] I have not made _any_ changes in the `charts/` directory.


<!--
NOTE:
Do *not* mix code changes with chart changes, it will break the release process.
Delete the checklist section that doesn't apply to the change.

NOTE:
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->

fixes #955
