### PR TITLE
feat: documentation structure attribution

### DIFF
--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -30,7 +30,7 @@ TIP: The xref:tutorials/tutorial.adoc[tutorial] gives you a glimpse into K8up. G
 [discrete]
 == Documentation
 
-The documentation is inspired by the https://documentation.divio.com/[Divio's documentation structure]:
+The documentation is inspired by the https://diataxis.fr/[Diátaxis documentation structure]:
 
 Tutorials:: _Learning-oriented_: Simple lessons to learn about K8up.
 


### PR DESCRIPTION
Maybe I am mistaken, but the documentation structure is not from Divio, but from [Diátaxis](https://diataxis.fr/).

Let's give credits where they are due.

I am a big fan of this framework and it helped me a lot.