### PR TITLE
Remove bitnami image for `cleanup` jobs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,9 @@ RUN apk add --update --no-cache \
     curl \
     fuse \
     openssh-client \
-    tzdata
+    tzdata \
+    kubectl \
+    jq
 
 ENV RESTIC_BINARY=/usr/local/bin/restic
 

--- a/charts/k8up/Chart.yaml
+++ b/charts/k8up/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
   - backup
   - operator
   - restic
-version: 4.8.5
+version: 4.8.6
 sources:
   - https://github.com/k8up-io/k8up
 maintainers:

--- a/charts/k8up/README.md
+++ b/charts/k8up/README.md
@@ -1,6 +1,6 @@
 # k8up
 
-![Version: 4.8.5](https://img.shields.io/badge/Version-4.8.5-informational?style=flat-square)
+![Version: 4.8.6](https://img.shields.io/badge/Version-4.8.6-informational?style=flat-square)
 
 Kubernetes and OpenShift Backup Operator based on restic
 
@@ -13,7 +13,7 @@ helm repo add k8up-io https://k8up-io.github.io/k8up
 helm install k8up k8up-io/k8up
 ```
 ```bash
-kubectl apply -f https://github.com/k8up-io/k8up/releases/download/k8up-4.8.5/k8up-crd.yaml --server-side
+kubectl apply -f https://github.com/k8up-io/k8up/releases/download/k8up-4.8.6/k8up-crd.yaml --server-side
 ```
 
 <!---
@@ -41,14 +41,14 @@ Document your changes in values.yaml and let `make docs:helm` generate this sect
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` |  |
-| cleanup.pullPolicy | string | `"IfNotPresent"` | Cleanup-job image pull policy |
-| cleanup.registry | string | `"docker.io"` | Cleanup-job image registry |
-| cleanup.repository | string | `"bitnami/kubectl"` | Cleanup-job image repository |
-| cleanup.tag | string | `"latest"` | Cleanup-job image tag (version) |
+| cleanup.pullPolicy | string | `""` | Cleanup-job image pull policy *deprecated*. Will default to image.pullPolicy |
+| cleanup.registry | string | `""` | Cleanup-job image registry *deprecated*. Will default to image.registry |
+| cleanup.repository | string | `""` | Cleanup-job image repository *deprecated*. Will default to image.repository |
+| cleanup.tag | string | `""` | Cleanup-job image tag (version) *deprecated*. Will default to image.tag |
 | image.pullPolicy | string | `"IfNotPresent"` | Operator image pull policy |
 | image.registry | string | `"ghcr.io"` | Operator image registry |
 | image.repository | string | `"k8up-io/k8up"` | Operator image repository |
-| image.tag | string | `"v2.13.0"` | Operator image tag (version) |
+| image.tag | string | `"v2.13.1"` | Operator image tag (version) |
 | imagePullSecrets | list | `[]` |  |
 | k8up.backupImage.repository | string | `""` | The backup runner image repository. Defaults to `{image.registry}/{image.repository}`. Specify an image repository including registry, e.g. `example.com/repo/image` |
 | k8up.backupImage.tag | string | `""` | The backup runner image tag Defaults to `{image.tag}` |

--- a/charts/k8up/templates/_helpers.tpl
+++ b/charts/k8up/templates/_helpers.tpl
@@ -86,6 +86,6 @@ Cleanup Image
 */}}
 {{- define "cleanupImage" -}}
 {{- with .Values -}}
-{{ if .cleanup.registry }}{{ .cleanup.registry }}/{{ end }}{{ .cleanup.repository }}:{{ .cleanup.tag }}
+{{ if .cleanup.registry }}{{ .cleanup.registry }}{{ else }}{{ .image.registry }}{{ end }}/{{ if .cleanup.repository }}{{ .cleanup.repository }}{{ else }}{{ .image.repository }}{{ end }}:{{ if .cleanup.tag }}{{ .cleanup.tag }}{{ else }}{{ .image.tag }}{{ end }}
 {{- end -}}
 {{- end -}}

--- a/charts/k8up/templates/cleanup-hook.yaml
+++ b/charts/k8up/templates/cleanup-hook.yaml
@@ -86,13 +86,13 @@ spec:
       containers:
       - name: "{{ .Release.Name }}-cleanup"
         image: "{{ include "cleanupImage" . }}"
-        imagePullPolicy: {{ .Values.cleanup.pullPolicy }}
+        imagePullPolicy: {{ if .Values.cleanup.pullPolicy }}{{ .Values.cleanup.pullPolicy }}{{ else }}{{ .Values.image.pullPolicy }}{{ end }}
         command:
           - sh
           - -c
         args:
           - |
-            #!/bin/bash
+            set -eo pipefail
 
             NAMESPACES=$(kubectl get namespace -ojson | jq -r '.items[].metadata.name')
 

--- a/charts/k8up/values.yaml
+++ b/charts/k8up/values.yaml
@@ -10,7 +10,7 @@ image:
   # -- Operator image repository
   repository: k8up-io/k8up
   # -- Operator image tag (version)
-  tag: v2.13.0
+  tag: v2.13.1
 
 imagePullSecrets: []
 serviceAccount:
@@ -151,11 +151,11 @@ resources:
     memory: 128Mi
 
 cleanup:
-  # -- Cleanup-job image pull policy
-  pullPolicy: IfNotPresent
-  # -- Cleanup-job image registry
-  registry: docker.io
-  # -- Cleanup-job image repository
-  repository: bitnami/kubectl
-  # -- Cleanup-job image tag (version)
-  tag: latest
+  # -- Cleanup-job image pull policy *deprecated*. Will default to image.pullPolicy
+  pullPolicy: ""
+  # -- Cleanup-job image registry *deprecated*. Will default to image.registry
+  registry: ""
+  # -- Cleanup-job image repository *deprecated*. Will default to image.repository
+  repository: ""
+  # -- Cleanup-job image tag (version) *deprecated*. Will default to image.tag
+  tag: ""


### PR DESCRIPTION
## Summary

The Bitnami images got removed completely.

We add all required binaries into the k8up image, use the k8up image for cleanup jobs, and deprecate the old parameters referencing the cleanup image.

## Checklist

### For Helm Chart changes

- [x] Categorize the PR by setting a good title and adding one of the labels:
  `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
  as they show up in the changelog
- [x] PR contains the label `area:chart`
- [x] PR contains the chart label, e.g. `chart:k8up`
- [x] Commits are [signed off](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
- [x] Variables are documented in the values.yaml using the format required by [Helm-Docs](https://github.com/norwoodj/helm-docs#valuesyaml-metadata).
- [x] Chart Version bumped if immediate release after merging is planned
- [x] I have run `make chart-docs`
- [x] Link this PR to related code release or other issues.

<!--
NOTE:
Do *not* mix code changes with chart changes, it will break the release process.
Delete the checklist section that doesn't apply to the change.

NOTE:
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
