### PR TITLE
bug: truncate volume names to 63 characters in BackupController executor

### DIFF
--- a/operator/backupcontroller/backup_utils_test.go
+++ b/operator/backupcontroller/backup_utils_test.go
@@ -2,6 +2,7 @@ package backupcontroller
 
 import (
 	"testing"
+	"strings"
 
 	v1 "github.com/k8up-io/k8up/v2/api/v1"
 	"github.com/k8up-io/k8up/v2/operator/cfg"
@@ -76,6 +77,31 @@ func TestBackupExecutor_setupEnvVars(t *testing.T) {
 			for _, expectedEnv := range tt.expectedEnvVars {
 				assert.Contains(t, result, expectedEnv)
 			}
+		})
+	}
+}
+
+func TestTruncateVolumeName(t *testing.T) {
+	tests := map[string]struct {
+		input    string
+		expected string
+	}{
+		"short name": {
+			input:    "my-pvc",
+			expected: "my-pvc",
+		},
+		"exactly 63 chars": {
+			input:    strings.Repeat("a", 63),
+			expected: strings.Repeat("a", 63),
+		},
+		"over 63 chars": {
+			input:    strings.Repeat("a", 100),
+			expected: strings.Repeat("a", 63),
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, truncateVolumeName(tc.input))
 		})
 	}
 }

--- a/operator/backupcontroller/executor.go
+++ b/operator/backupcontroller/executor.go
@@ -122,7 +122,7 @@ func (b *BackupExecutor) listAndFilterPVCs(ctx context.Context, annotation strin
 
 		bi := backupItem{
 			volume: corev1.Volume{
-				Name: pvc.Name,
+				Name: truncateVolumeName(pvc.Name),
 				VolumeSource: corev1.VolumeSource{
 					PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
 						ClaimName: pvc.Name,
@@ -368,4 +368,12 @@ func (b *BackupExecutor) attachTLSVolumeMounts() []corev1.VolumeMount {
 	}
 
 	return utils.AttachEmptyDirVolumeMounts(cfg.Config.PodVarDir, &tlsVolumeMounts)
+}
+
+// truncateVolumeName ensures the volume name doesn't exceed the Kubernetes 63-character limit.
+func truncateVolumeName(name string) string {
+	if len(name) > 63 {
+		return name[:63]
+	}
+	return name
 }


### PR DESCRIPTION
## Summary

This PR fixes volume name handling in the BackupController executor to comply with Kubernetes’ 63-character limit.
volumes[*].name is now automatically truncated to 63 characters, preventing errors caused by longer names.
Other related fields, such as persistentVolumeClaim.claimName and configMap.name, remain unaffected.

Related Issue:
[Fixes k8up-io/k8up#862](https://github.com/k8up-io/k8up/issues/862)