### PR TITLE
Bug fix env var names BACKUP_GLOBAL_... for request and limit in helm chart

### DIFF
--- a/charts/k8up/templates/deployment.yaml
+++ b/charts/k8up/templates/deployment.yaml
@@ -49,19 +49,19 @@ spec:
                   fieldPath: metadata.namespace
           {{- end }}
           {{- with .Values.k8up.globalResources.requests.cpu }}
-            - name: BACKUP_GLOBALCPU_REQUEST
+            - name: BACKUP_GLOBAL_CPU_REQUEST
               value: {{ . }}
           {{- end }}
           {{- with .Values.k8up.globalResources.requests.memory }}
-            - name: BACKUP_GLOBALMEMORY_REQUEST
+            - name: BACKUP_GLOBAL_MEMORY_REQUEST
               value: {{ . }}
           {{- end }}
           {{- with .Values.k8up.globalResources.limits.cpu }}
-            - name: BACKUP_GLOBALCPU_LIMIT
+            - name: BACKUP_GLOBAL_CPU_LIMIT
               value: {{ . }}
           {{- end }}
           {{- with .Values.k8up.globalResources.limits.memory }}
-            - name: BACKUP_GLOBALMEMORY_LIMIT
+            - name: BACKUP_GLOBAL_MEMORY_LIMIT
               value: {{ . }}
           {{- end }}
           {{- if .Values.k8up.envVars }}


### PR DESCRIPTION

## Summary

Fixes wrong env var names in helm chart, see this code for references of the correct env var names: https://github.com/k8up-io/k8up/blob/56ca1a38786778474be6260d7c90f65e40a3eff8/cmd/operator/main.go#L65-L68


## Checklist

### For Helm Chart changes

- [ ] Categorize the PR by setting a good title and adding one of the labels:
  `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
  as they show up in the changelog
- [ ] PR contains the label `area:chart`
- [ ] PR contains the chart label, e.g. `chart:k8up`
- [ ] Commits are [signed off](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
- [ ] Variables are documented in the values.yaml using the format required by [Helm-Docs](https://github.com/norwoodj/helm-docs#valuesyaml-metadata).
- [ ] Chart Version bumped if immediate release after merging is planned
- [ ] I have run `make chart-docs`
- [ ] Link this PR to related code release or other issues.

<!--
NOTE:
Do *not* mix code changes with chart changes, it will break the release process.
Delete the checklist section that doesn't apply to the change.

NOTE:
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
