### PR TITLE
Fix cluster label in backup metrics

### DIFF
--- a/operator/backupcontroller/backup_utils.go
+++ b/operator/backupcontroller/backup_utils.go
@@ -189,6 +189,7 @@ func (b *BackupExecutor) setupEnvVars() ([]corev1.EnvVar, error) {
 
 	vars.SetStringOrDefault("STATS_URL", b.backup.Spec.StatsURL, cfg.Config.GlobalStatsURL)
 	vars.SetStringOrDefault("PROM_URL", b.backup.Spec.PromURL, cfg.Config.PromURL)
+	vars.SetStringOrDefault("CLUSTER_NAME", b.backup.Spec.ClusterName, cfg.Config.ClusterName)
 	vars.SetString("BACKUPCOMMAND_ANNOTATION", cfg.Config.BackupCommandAnnotation)
 	vars.SetString("FILEEXTENSION_ANNOTATION", cfg.Config.FileExtensionAnnotation)
 

--- a/operator/checkcontroller/executor.go
+++ b/operator/checkcontroller/executor.go
@@ -96,6 +96,7 @@ func (c *CheckExecutor) setupEnvVars(ctx context.Context) []corev1.EnvVar {
 	}
 
 	vars.SetString("PROM_URL", cfg.Config.PromURL)
+	vars.SetString("CLUSTER_NAME", cfg.Config.ClusterName)
 
 	err := vars.Merge(executor.DefaultEnv(c.Obj.GetNamespace()))
 	if err != nil {


### PR DESCRIPTION
## Summary

This PR fixes an issue with the Prometheus metrics sent from the restic backup pod to the pushgateway, specifically concerning the "cluster" label.

The "cluster" label was introduced in #1030. However, this label doesn't currently works as intended. The clusterName values from the backup/schedule manifest are not being passed to the backup pod's environment. As a result, the "cluster" label consistently appears empty ("") in pushgateway/prometheus.

Additionally, there is another point to discuss.
These two PRs #1030 and #260 added ClusterName and PromURL to "restic check" (./api/v1/check_types.go)
 code, which are intended for the code that pushes metrics to Pushgateway. It appears the actual code implementing this push functionality is missing, At least, I was unable to find it. So the "check" job doesn't push any metrics.

A reasonable solution might be to completely remove these configurations and clean the CRDs accordingly. But since these would be breaking changes, I have left the existing code unchanged, assuming that the metrics-pushing code either exists elsewhere or will be implemented in the future.


## Checklist

### For Code changes

- [x] Categorize the PR by setting a good title and adding one of the labels:
  `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
  as they show up in the changelog
- [x] PR contains the label `area:operator`
- [x] Commits are [signed off](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
- [x] Link this PR to related issues
- [x] I have not made _any_ changes in the `charts/` directory.

<!--
NOTE:
Do *not* mix code changes with chart changes, it will break the release process.
Delete the checklist section that doesn't apply to the change.

NOTE:
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
