### PR TITLE
Improve sleep for reliable repository creation

### DIFF
--- a/operator/backupcontroller/executor.go
+++ b/operator/backupcontroller/executor.go
@@ -301,12 +301,13 @@ func (b *BackupExecutor) startBackup(ctx context.Context) error {
 					Value: "true",
 				})
 			}
-			// each job sleeps for index seconds to avoid concurrent restic repository creation. Not the prettiest way but it works and a repository
+			// each job sleeps for index * 10 seconds to avoid concurrent restic repository creation. Not the prettiest way but it works and a repository
 			// is created only once usually.
 			if name == "prebackup" || index != 0 {
+				secondsToSleep := time.Duration(index*10) * time.Second
 				batchJob.job.Spec.Template.Spec.Containers[0].Env = append(batchJob.job.Spec.Template.Spec.Containers[0].Env, corev1.EnvVar{
 					Name:  "SLEEP_DURATION",
-					Value: (3 * time.Second).String(),
+					Value: secondsToSleep.String(),
 				})
 			}
 			b.backup.Spec.AppendEnvFromToContainer(&batchJob.job.Spec.Template.Spec.Containers[0])


### PR DESCRIPTION
## Summary

The SLEEP_DURATION was always set to 3 seconds which defeated the
purpose of the option. By setting it to index * 10 seconds the gap
between can be noticed and should improve the reliability of the
restic repository creation.

## Checklist

### For Code changes

- [ ] Categorize the PR by setting a good title and adding one of the labels:
  `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
  as they show up in the changelog
- [ ] PR contains the label `area:operator`
- [x] Commits are [signed off](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
- n/a: Link this PR to related issues
- [x] I have not made _any_ changes in the `charts/` directory.