### PR TITLE
Add Codecov coverage reporting to CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,3 +33,16 @@ jobs:
 
     - name: Run integration tests
       run: make integration-test
+
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v5
+      with:
+        files: cover.out
+        fail_ci_if_error: false
+
+    - name: Upload test results to Codecov
+      if: ${{ !cancelled() }}
+      uses: codecov/test-results-action@v1
+      with:
+        files: unit-tests.xml
+        fail_ci_if_error: false

--- a/Makefile
+++ b/Makefile
@@ -30,8 +30,8 @@ include Makefile.restic-integration.mk envtest/integration.mk
 go_build ?= $(GO_EXEC) build -o $(BIN_FILENAME) $(K8UP_MAIN_GO)
 
 .PHONY: test
-test: ## Run tests
-	$(GO_EXEC) test ./... -coverprofile cover.out
+test: ## Run tests, generate coverage profile and JUnit XML report
+	$(GO_EXEC) run gotest.tools/gotestsum@latest --junitfile unit-tests.xml -- ./... -coverprofile cover.out
 
 .PHONY: build
 build: generate fmt vet $(BIN_FILENAME) docs-update-usage ## Build manager binary


### PR DESCRIPTION
## Summary

- Add **Codecov coverage reporting** — uploads `cover.out` from `go test`
- Add **Codecov Test Analytics** — uploads JUnit XML test results via `gotestsum` for:
  - Flaky test detection
  - Test duration trends
  - Test failure tracking over time
- Use `gotestsum` to run tests (produces JUnit XML + replaces `make test`)

### Setup

The Codecov GitHub App has been installed on the k8up-io org. For public repos, no upload token is needed.

### What you get

| Feature | Source | What it shows |
|---------|--------|---------------|
| Coverage | `cover.out` | Line coverage per file, PR diffs, trends |
| Test Analytics | `unit-tests.xml` | Flaky tests, slowest tests, failure rates |

### Current baseline

**13.4% total coverage.** Key areas:

| Package | Coverage |
|---------|----------|
| operator/utils | 83.2% |
| operator/scheduler | 67.9% |
| operator/schedulecontroller | 56.8% |
| operator/cfg | 41.9% |
| operator/locker | 31.5% |
| api/v1 | 19.4% |
| restic/cli | 14.1% |
| restic/kubernetes | 13.6% |
| operator/executor | 9.3% |
| operator/job | 4.5% |
| Several packages | 0.0% |

### Why this matters

At 13.4% test coverage, most of the operator runs untested in production. Measuring and visualizing coverage helps increase it over time — contributors see which lines their PR covers, reviewers can spot untested paths, and maintainers can set a "no decrease" rule to ratchet coverage up gradually.

## Test plan

- [ ] Verify Codecov coverage upload works
- [ ] Verify Test Analytics upload works
- [ ] Check Codecov dashboard after first upload

🤖 Generated with [Claude Code](https://claude.com/claude-code)