### PR TITLE
Only run govulncheck when Go dependencies change

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -2,15 +2,15 @@ name: Go Vulnerability Check
 
 on:
   pull_request:
-    paths-ignore:
-      - 'docs/**'
-      - 'charts/**'
+    paths:
+      - '**/go.mod'
+      - '**/go.sum'
   push:
     branches:
       - master
-    paths-ignore:
-      - 'docs/**'
-      - 'charts/**'
+    paths:
+      - '**/go.mod'
+      - '**/go.sum'
   schedule:
     # Run weekly on Monday to catch newly disclosed vulnerabilities
     - cron: '0 8 * * 1'


### PR DESCRIPTION
## Summary

Change govulncheck trigger from `paths-ignore` (runs on almost everything) to `paths` (only `go.mod`/`go.sum`). Vulnerability status only changes when:
- Dependencies change → triggered by `go.mod`/`go.sum` paths
- New CVEs are disclosed → caught by weekly schedule (unchanged)

Code-only changes don't affect vulnerability status.

## Test plan

- [ ] Verify govulncheck runs on dependency PRs
- [ ] Verify govulncheck does NOT run on code-only PRs
- [ ] Verify weekly schedule still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)