### PR TITLE
fix(#1189): Unset `BACKUP_PROMURL` when not explitly set in helm values

### DIFF
--- a/charts/k8up/templates/_helpers.tpl
+++ b/charts/k8up/templates/_helpers.tpl
@@ -100,3 +100,14 @@ Cleanup Image
 {{ if .cleanup.registry }}{{ .cleanup.registry }}{{ else }}{{ .image.registry }}{{ end }}/{{ if .cleanup.repository }}{{ .cleanup.repository }}{{ else }}{{ .image.repository }}{{ end }}:{{ if .cleanup.tag }}{{ .cleanup.tag }}{{ else }}{{ .image.tag }}{{ end }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+User defined envVar keys as space separated list
+*/}}
+{{- define "userDefinedEnvVarKeys" -}}
+{{- $keys := list }}
+{{- range .Values.k8up.envVars }}
+  {{- $keys = append $keys .name }}
+{{- end }}
+{{- $keys | join " " }}
+{{- end -}}

--- a/charts/k8up/templates/deployment.yaml
+++ b/charts/k8up/templates/deployment.yaml
@@ -65,6 +65,10 @@ spec:
             - name: BACKUP_GLOBAL_MEMORY_LIMIT
               value: {{ . }}
           {{- end }}
+          {{- if include "userDefinedEnvVarKeys" . | contains "BACKUP_PROMURL" | not }}
+            - name: BACKUP_PROMURL
+              value: ""
+          {{- end }}
           {{- if .Values.k8up.envVars }}
             {{- toYaml .Values.k8up.envVars | nindent 12 }}
           {{- end }}

--- a/charts/k8up/test/deployment_test.go
+++ b/charts/k8up/test/deployment_test.go
@@ -42,8 +42,10 @@ func Test_Deployment_ShouldRender_EnvironmentVariables(t *testing.T) {
 	assert.Equal(t, "metadata.namespace", envs[4].ValueFrom.FieldRef.FieldPath)
 	assert.Equal(t, "BACKUP_GLOBAL_CPU_REQUEST", envs[5].Name, "Deployment does not use configured Env Name")
 	assert.Equal(t, wantCpuRequest, envs[5].Value, "Deployment does not use configured Env Value")
-	assert.Equal(t, "VARIABLE", envs[6].Name, "Deployment does not use configured Env Name")
-	assert.Equal(t, "VALUE", envs[6].Value, "Deployment does not use configured Env Value")
+	assert.Equal(t, "BACKUP_PROMURL", envs[6].Name, "Deployment does not use configured Env Name")
+	assert.Equal(t, "", envs[6].Value, "Deployment does not use configured Env Value")
+	assert.Equal(t, "VARIABLE", envs[7].Name, "Deployment does not use configured Env Name")
+	assert.Equal(t, "VALUE", envs[7].Value, "Deployment does not use configured Env Value")
 }
 
 func Test_Deployment_ShouldRender_Affinity(t *testing.T) {


### PR DESCRIPTION
## Summary

This pr unsets the global default prometheus url on the operator (`BACKUP_PROMURL`), unless it is explicitly set in the helm values.

Unless there was a reason for the default of `https://127.0.0.1/`, this should not be a breaking change.

I created this pr to address #1189.

## Checklist

### For Helm Chart changes

- [ ] Categorize the PR by setting a good title and adding one of the labels:
  `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
  as they show up in the changelog
- [ ] PR contains the label `area:chart`
- [ ] PR contains the chart label, e.g. `chart:k8up`
- [x] Commits are [signed off](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
- [x] Variables are documented in the values.yaml using the format required by [Helm-Docs](https://github.com/norwoodj/helm-docs#valuesyaml-metadata).
- [ ] Chart Version bumped if immediate release after merging is planned
- [ ] I have run `make chart-docs`
- [x] Link this PR to related code release or other issues.

<!--
NOTE:
Do *not* mix code changes with chart changes, it will break the release process.
Delete the checklist section that doesn't apply to the change.

NOTE:
CI-only changes (GitHub Actions workflows, linter configs, etc.) do not need
an area label — the area labels are for code and chart changes only.

NOTE:
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
