### PR TITLE
Update Docs backupResticArgs annotation documentation

### DIFF
--- a/docs/modules/ROOT/pages/references/annotations.adoc
+++ b/docs/modules/ROOT/pages/references/annotations.adoc
@@ -42,4 +42,10 @@ See xref:references/operator-config-reference.adoc[Operator Configuration refere
 |A string which is a valid node name.
 |`PersistentVolumeClaim`
 |n/a
+
+|`k8up.io/backup-restic-args`
+|Arguments for restic.
+|JSON string array
+|`PersistentVolumeClaim`
+|`BACKUP_RESTICARGSANNOTATION`
 |===


### PR DESCRIPTION
## Summary

* Added resticBackupsArgs to the Annotation Documentation

## Checklist

### For Code changes

- [x] Categorize the PR by setting a good title and adding one of the labels:
  `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
  as they show up in the changelog
- [x] PR contains the label `area:operator`
- [x] Commits are [signed off](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
- [ ] Link this PR to related issues
- [x] I have not made _any_ changes in the `charts/` directory.

<!--
NOTE:
Do *not* mix code changes with chart changes, it will break the release process.
Delete the checklist section that doesn't apply to the change.

NOTE:
CI-only changes (GitHub Actions workflows, linter configs, etc.) do not need
an area label — the area labels are for code and chart changes only.

NOTE:
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
