### PR TITLE
On schedule creation, create labeled metrics with value 0

### DIFF
--- a/operator/monitoring/prometheus.go
+++ b/operator/monitoring/prometheus.go
@@ -35,6 +35,12 @@ var (
 	})
 )
 
+func CreateLabel(namespace string, jobType v1.JobType) {
+	metricsFailureCounter.WithLabelValues(namespace, jobType.String())
+	metricsSuccessCounter.WithLabelValues(namespace, jobType.String())
+	metricsTotalCounter.WithLabelValues(namespace, jobType.String())
+}
+
 func IncFailureCounters(namespace string, jobType v1.JobType) {
 	metricsFailureCounter.WithLabelValues(namespace, jobType.String()).Inc()
 	metricsTotalCounter.WithLabelValues(namespace, jobType.String()).Inc()

--- a/operator/monitoring/prometheus.go
+++ b/operator/monitoring/prometheus.go
@@ -40,6 +40,12 @@ var (
 	}, []string{"namespace", "schedule", "jobType"})
 )
 
+func CreateLabels(namespace string, jobType v1.JobType) {
+	metricsFailureCounter.WithLabelValues(namespace, jobType.String())
+	metricsSuccessCounter.WithLabelValues(namespace, jobType.String())
+	metricsTotalCounter.WithLabelValues(namespace, jobType.String())
+}
+
 func IncFailureCounters(namespace string, jobType v1.JobType) {
 	metricsFailureCounter.WithLabelValues(namespace, jobType.String()).Inc()
 	metricsTotalCounter.WithLabelValues(namespace, jobType.String()).Inc()

--- a/operator/schedulecontroller/handler.go
+++ b/operator/schedulecontroller/handler.go
@@ -129,6 +129,7 @@ func (s *ScheduleHandler) createJobList(ctx context.Context, sched scheduler.Sch
 		}
 		if !hasSchedule {
 			monitoring.IncRegisteredSchedulesGauge(s.schedule.Namespace)
+			monitoring.CreateLabel(s.schedule.Namespace, jobType)
 		}
 		template := jb.spec.GetDeepCopy()
 		s.mergeWithDefaults(template.GetRunnableSpec())

--- a/operator/schedulecontroller/handler.go
+++ b/operator/schedulecontroller/handler.go
@@ -129,6 +129,7 @@ func (s *ScheduleHandler) createJobList(ctx context.Context, sched scheduler.Sch
 		}
 		if !hasSchedule {
 			monitoring.IncRegisteredSchedulesGauge(s.schedule.Namespace)
+			monitoring.CreateLabels(s.schedule.Namespace, jobType)
 		}
 		template := jb.spec.GetDeepCopy()
 		s.mergeWithDefaults(template.GetRunnableSpec())


### PR DESCRIPTION
## Summary

This change will report metrics for schedules starting at 0. Previously metrics started with value 1 only after a schedule has triggered.

Fixes https://github.com/k8up-io/k8up/issues/976