### PR TITLE
docs/restore.adoc: add restoreMethod to first restore example

### DIFF
--- a/docs/modules/ROOT/pages/how-tos/restore.adoc
+++ b/docs/modules/ROOT/pages/how-tos/restore.adoc
@@ -41,6 +41,8 @@ kind: Restore
 metadata:
   name: restore-test
 spec:
+  restoreMethod:
+    s3: ...
   snapshot: 162e7a85acbc14de93dad31a3699331cb32187ff0d7bd2227b7c4362a1d13a42
   backend:
     ...


### PR DESCRIPTION
## Summary

* A doc change to increase the chances of the first copy paste for a restore to succeed
* I copied the first example and then failed miserably. See https://github.com/k8up-io/k8up/issues/1210
