### PR TITLE
Restrict job history cleanup to siblings of the same owner

### DIFF
--- a/operator/archivecontroller/executor.go
+++ b/operator/archivecontroller/executor.go
@@ -128,7 +128,7 @@ func (a *ArchiveExecutor) setupEnvVars(ctx context.Context, archive *k8upv1.Arch
 }
 
 func (a *ArchiveExecutor) cleanupOldArchives(ctx context.Context, archive *k8upv1.Archive) {
-	a.CleanupOldResources(ctx, &k8upv1.ArchiveList{}, archive.Namespace, archive)
+	a.CleanupOldResources(ctx, &k8upv1.ArchiveList{}, archive)
 }
 
 func (a *ArchiveExecutor) attachTLSVolumeMounts() []corev1.VolumeMount {

--- a/operator/backupcontroller/executor.go
+++ b/operator/backupcontroller/executor.go
@@ -396,7 +396,7 @@ func (b *BackupExecutor) createJob(name, node string, tolerations []corev1.Toler
 }
 
 func (b *BackupExecutor) cleanupOldBackups(ctx context.Context) {
-	b.CleanupOldResources(ctx, &k8upv1.BackupList{}, b.backup.Namespace, b.backup)
+	b.CleanupOldResources(ctx, &k8upv1.BackupList{}, b.backup)
 }
 
 func (b *BackupExecutor) jobName(name string) string {

--- a/operator/checkcontroller/executor.go
+++ b/operator/checkcontroller/executor.go
@@ -107,7 +107,7 @@ func (c *CheckExecutor) setupEnvVars(ctx context.Context) []corev1.EnvVar {
 }
 
 func (c *CheckExecutor) cleanupOldChecks(ctx context.Context, check *k8upv1.Check) {
-	c.CleanupOldResources(ctx, &k8upv1.CheckList{}, check.Namespace, check)
+	c.CleanupOldResources(ctx, &k8upv1.CheckList{}, check)
 }
 
 func (c *CheckExecutor) attachTLSVolumeMounts() []corev1.VolumeMount {

--- a/operator/executor/generic.go
+++ b/operator/executor/generic.go
@@ -6,10 +6,13 @@ package executor
 
 import (
 	"context"
+	"strings"
 
 	k8upv1 "github.com/k8up-io/k8up/v2/api/v1"
 	"github.com/k8up-io/k8up/v2/operator/executor/cleaner"
 	"github.com/k8up-io/k8up/v2/operator/job"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -39,18 +42,62 @@ type jobObjectList interface {
 	GetJobObjects() k8upv1.JobObjectList
 }
 
-func (g *Generic) CleanupOldResources(ctx context.Context, typ jobObjectList, namespace string, limits cleaner.GetJobsHistoryLimiter) {
-	err := g.listOldResources(ctx, namespace, typ)
+// CleanupJobObject is satisfied by the running job. It is used to scope
+// history-limit cleanup to siblings of that job — jobs that share the same
+// owner, e.g. the same Schedule.
+type CleanupJobObject interface {
+	client.Object
+	cleaner.GetJobsHistoryLimiter
+}
+
+func (g *Generic) CleanupOldResources(ctx context.Context, typ jobObjectList, runningJob CleanupJobObject) {
+	err := g.listOldResources(ctx, runningJob.GetNamespace(), typ)
 	if err != nil {
 		return
 	}
 
-	cl := cleaner.NewObjectCleaner(g.Client, limits)
-	deleted, err := cl.CleanOldObjects(ctx, typ.GetJobObjects())
+	// Multiple Schedules creating jobs of the same kind in the same namespace
+	// are otherwise indistinguishable at cleanup time, so a busy Schedule could
+	// evict every recent job from a less busy one — making backups look like
+	// they never ran. Restrict cleanup to siblings of the running job.
+	siblings := filterByController(typ.GetJobObjects(), runningJob)
+
+	cl := cleaner.NewObjectCleaner(g.Client, runningJob)
+	deleted, err := cl.CleanOldObjects(ctx, siblings)
 	if err != nil {
 		g.SetConditionFalseWithMessage(ctx, k8upv1.ConditionScrubbed, k8upv1.ReasonDeletionFailed, "could not cleanup old resources: %s", err.Error())
 		return
 	}
 	g.SetConditionTrueWithMessage(ctx, k8upv1.ConditionScrubbed, k8upv1.ReasonSucceeded, "Deleted %d resources", deleted)
 
+}
+
+// filterByController returns only those jobs that share the same owner UID as
+// runningJob, as resolved by controllerUID. If runningJob has no owner (e.g. a
+// one-off Backup created directly by the user), the result contains only jobs
+// that also have none.
+func filterByController(jobs k8upv1.JobObjectList, runningJob client.Object) k8upv1.JobObjectList {
+	ownerUID := controllerUID(runningJob)
+	filtered := make(k8upv1.JobObjectList, 0, len(jobs))
+	for _, j := range jobs {
+		if controllerUID(j) == ownerUID {
+			filtered = append(filtered, j)
+		}
+	}
+	return filtered
+}
+
+func controllerUID(obj metav1.Object) types.UID {
+	if ref := metav1.GetControllerOf(obj); ref != nil {
+		return ref.UID
+	}
+	// Jobs created before k8up set Controller=true carry the Schedule owner
+	// reference without the flag. Fall back to it so pre-upgrade jobs group
+	// with their Schedule instead of with standalone jobs.
+	for _, ref := range obj.GetOwnerReferences() {
+		if ref.Kind == "Schedule" && strings.HasPrefix(ref.APIVersion, k8upv1.GroupVersion.Group+"/") {
+			return ref.UID
+		}
+	}
+	return ""
 }

--- a/operator/executor/generic_test.go
+++ b/operator/executor/generic_test.go
@@ -1,0 +1,161 @@
+package executor
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	k8upv1 "github.com/k8up-io/k8up/v2/api/v1"
+	"github.com/k8up-io/k8up/v2/operator/job"
+)
+
+func TestFilterByController_GroupsBySchedule(t *testing.T) {
+	scheduleA := backupOwnedBy("a", "schedule-a")
+	scheduleB1 := backupOwnedBy("b1", "schedule-b")
+	scheduleB2 := backupOwnedBy("b2", "schedule-b")
+	standalone := backupOwnedBy("standalone", "")
+
+	jobs := k8upv1.JobObjectList{&scheduleA, &scheduleB1, &scheduleB2, &standalone}
+
+	filtered := filterByController(jobs, &scheduleB1)
+
+	assert.Len(t, filtered, 2)
+	assert.Contains(t, filtered, k8upv1.JobObject(&scheduleB1))
+	assert.Contains(t, filtered, k8upv1.JobObject(&scheduleB2))
+}
+
+func TestFilterByController_LegacyOwnerRefsGroupWithTheirSchedule(t *testing.T) {
+	current := backupOwnedBy("a-new", "schedule-a")
+	legacyA := legacyBackupOwnedBy("a-legacy", "schedule-a")
+	legacyB := legacyBackupOwnedBy("b-legacy", "schedule-b")
+	standalone := backupOwnedBy("standalone", "")
+
+	jobs := k8upv1.JobObjectList{&current, &legacyA, &legacyB, &standalone}
+
+	filtered := filterByController(jobs, &current)
+
+	assert.Len(t, filtered, 2)
+	assert.Contains(t, filtered, k8upv1.JobObject(&current))
+	assert.Contains(t, filtered, k8upv1.JobObject(&legacyA))
+}
+
+func TestFilterByController_StandalonesGroupTogether(t *testing.T) {
+	scheduleA := backupOwnedBy("a", "schedule-a")
+	standalone1 := backupOwnedBy("s1", "")
+	standalone2 := backupOwnedBy("s2", "")
+
+	jobs := k8upv1.JobObjectList{&scheduleA, &standalone1, &standalone2}
+
+	filtered := filterByController(jobs, &standalone1)
+
+	assert.Len(t, filtered, 2)
+	assert.Contains(t, filtered, k8upv1.JobObject(&standalone1))
+	assert.Contains(t, filtered, k8upv1.JobObject(&standalone2))
+}
+
+// TestCleanupOldResources_DoesNotEvictOtherSchedulesBackups is a regression
+// test for issue #1212. With successfulJobsHistoryLimit=1 set on Schedule A's
+// running Backup, Schedule B's backups must remain untouched — before the
+// fix, cleanup operated on all Backups in the namespace and a busy Schedule
+// could evict siblings owned by a different Schedule.
+func TestCleanupOldResources_DoesNotEvictOtherSchedulesBackups(t *testing.T) {
+	const ns = "myns"
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, clientgoscheme.AddToScheme(scheme))
+	require.NoError(t, k8upv1.AddToScheme(scheme))
+
+	now := time.Now()
+	runningA := newSuccessfulBackup("a-new", ns, "schedule-a", now)
+	runningA.Spec.SuccessfulJobsHistoryLimit = ptr.To(1)
+	oldA := newSuccessfulBackup("a-old", ns, "schedule-a", now.Add(-2*time.Hour))
+	oldB := newSuccessfulBackup("b-old", ns, "schedule-b", now.Add(-3*time.Hour))
+	olderB := newSuccessfulBackup("b-older", ns, "schedule-b", now.Add(-4*time.Hour))
+	legacyA := newSuccessfulBackup("a-legacy", ns, "schedule-a", now.Add(-5*time.Hour))
+	legacyA.OwnerReferences[0].Controller = nil
+
+	fclient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&k8upv1.Backup{}).
+		WithObjects(runningA, oldA, oldB, olderB, legacyA).
+		Build()
+
+	g := &Generic{Config: job.Config{Client: fclient, Obj: runningA}}
+	g.CleanupOldResources(context.Background(), &k8upv1.BackupList{}, runningA)
+
+	after := &k8upv1.BackupList{}
+	require.NoError(t, fclient.List(context.Background(), after))
+
+	remaining := make(map[string]bool, len(after.Items))
+	for _, b := range after.Items {
+		if b.DeletionTimestamp == nil {
+			remaining[b.Name] = true
+		}
+	}
+
+	assert.True(t, remaining["a-new"], "running backup must survive")
+	assert.False(t, remaining["a-old"], "schedule-a's history limit should have evicted a-old")
+	assert.False(t, remaining["a-legacy"], "backup created before the Controller flag was set must still be evicted by its schedule's history limit")
+	assert.True(t, remaining["b-old"], "schedule-b's backups must not be touched by schedule-a's cleanup")
+	assert.True(t, remaining["b-older"], "schedule-b's backups must not be touched by schedule-a's cleanup")
+}
+
+// backupOwnedBy returns a Backup whose controlling OwnerReference UID is set
+// to ownerUID. An empty ownerUID produces a Backup with no controller.
+func backupOwnedBy(name, ownerUID string) k8upv1.Backup {
+	b := k8upv1.Backup{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+	}
+	if ownerUID != "" {
+		b.OwnerReferences = []metav1.OwnerReference{{
+			APIVersion: k8upv1.GroupVersion.String(),
+			Kind:       "Schedule",
+			Name:       ownerUID,
+			UID:        types.UID(ownerUID),
+			Controller: ptr.To(true),
+		}}
+	}
+	return b
+}
+
+// legacyBackupOwnedBy returns a Backup as created by k8up before it set the
+// Controller flag: a Schedule owner reference without Controller=true.
+func legacyBackupOwnedBy(name, ownerUID string) k8upv1.Backup {
+	b := backupOwnedBy(name, ownerUID)
+	b.OwnerReferences[0].Controller = nil
+	return b
+}
+
+func newSuccessfulBackup(name, ns, scheduleUID string, createdAt time.Time) *k8upv1.Backup {
+	return &k8upv1.Backup{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              name,
+			Namespace:         ns,
+			CreationTimestamp: metav1.NewTime(createdAt),
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: k8upv1.GroupVersion.String(),
+				Kind:       "Schedule",
+				Name:       scheduleUID,
+				UID:        types.UID(scheduleUID),
+				Controller: ptr.To(true),
+			}},
+		},
+		Status: k8upv1.Status{
+			Conditions: []metav1.Condition{{
+				Type:               k8upv1.ConditionCompleted.String(),
+				Status:             metav1.ConditionTrue,
+				Reason:             k8upv1.ReasonSucceeded.String(),
+				LastTransitionTime: metav1.Now(),
+			}},
+		},
+	}
+}

--- a/operator/prunecontroller/executor.go
+++ b/operator/prunecontroller/executor.go
@@ -88,7 +88,7 @@ func (p *PruneExecutor) Exclusive() bool {
 }
 
 func (p *PruneExecutor) cleanupOldPrunes(ctx context.Context, prune *k8upv1.Prune) {
-	p.CleanupOldResources(ctx, &k8upv1.PruneList{}, prune.Namespace, prune)
+	p.CleanupOldResources(ctx, &k8upv1.PruneList{}, prune)
 }
 
 func (p *PruneExecutor) setupEnvVars(ctx context.Context, prune *k8upv1.Prune) []corev1.EnvVar {

--- a/operator/restorecontroller/executor.go
+++ b/operator/restorecontroller/executor.go
@@ -61,7 +61,7 @@ func (r *RestoreExecutor) Execute(ctx context.Context) error {
 }
 
 func (r *RestoreExecutor) cleanupOldRestores(ctx context.Context, restore *k8upv1.Restore) {
-	r.CleanupOldResources(ctx, &k8upv1.RestoreList{}, restore.Namespace, restore)
+	r.CleanupOldResources(ctx, &k8upv1.RestoreList{}, restore)
 }
 
 func (r *RestoreExecutor) createRestoreObject(ctx context.Context, restore *k8upv1.Restore) (*batchv1.Job, error) {

--- a/operator/schedulecontroller/handler.go
+++ b/operator/schedulecontroller/handler.go
@@ -153,8 +153,13 @@ func keyOf(schedule *k8upv1.Schedule, jobType k8upv1.JobType) string {
 func (s *ScheduleHandler) executeCronSchedule(ctx context.Context, obj k8upv1.JobObject) {
 	obj.SetNamespace(s.schedule.Namespace)
 	obj.SetName(generateName(obj.GetType(), s.schedule.Name))
-	_ = controllerutil.SetOwnerReference(s.schedule, obj, s.Client.Scheme())
 	log := controllerruntime.LoggerFrom(ctx)
+	// Controller=true is what lets history-limit cleanup scope to siblings of
+	// the same Schedule — see filterByController in operator/executor/generic.go.
+	if err := controllerutil.SetControllerReference(s.schedule, obj, s.Client.Scheme()); err != nil {
+		log.Error(err, "Could not set controller reference", "type", obj.GetType(), "namespace", obj.GetNamespace(), "name", obj.GetName())
+		return
+	}
 	err := s.Client.Create(ctx, obj.DeepCopyObject().(client.Object))
 	if err != nil {
 		log.Error(err, "Could not create new object", "type", obj.GetType(), "namespace", obj.GetNamespace(), "name", obj.GetName())

--- a/operator/schedulecontroller/schedule_integration_test.go
+++ b/operator/schedulecontroller/schedule_integration_test.go
@@ -7,7 +7,10 @@ import (
 
 	k8upv1 "github.com/k8up-io/k8up/v2/api/v1"
 	"github.com/k8up-io/k8up/v2/envtest"
+	"github.com/k8up-io/k8up/v2/operator/cfg"
+	"github.com/k8up-io/k8up/v2/operator/job"
 	"github.com/stretchr/testify/suite"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -69,6 +72,36 @@ func (ts *ScheduleControllerTestSuite) Test_GivenEffectiveScheduleWithRandomSche
 	ts.thenAssertCondition(actualSchedule, k8upv1.ConditionReady, k8upv1.ReasonReady, "resource is ready")
 	ts.Assert().Len(actualSchedule.Status.EffectiveSchedules, 1, "slice of effective schedules")
 	ts.Assert().NotEqual("somevaluetobechanged", actualSchedule.Status.EffectiveSchedules[0].GeneratedSchedule)
+}
+
+// Test_ExecuteCronSchedule_PersistsControllerOwnerReferenceOnCreatedJob is a
+// regression test for issue #1212: history-limit cleanup scopes jobs to their
+// Schedule via the controller OwnerReference (metav1.GetControllerOf), which
+// only matches a reference with Controller=true. The original bug survived its
+// unit tests because they hand-crafted Controller=true refs while production
+// used controllerutil.SetOwnerReference, which sets no Controller flag — so
+// real clusters still mixed jobs across Schedules. This drives the actual
+// executeCronSchedule path against a real apiserver and asserts the persisted
+// reference.
+func (ts *ScheduleControllerTestSuite) Test_ExecuteCronSchedule_PersistsControllerOwnerReferenceOnCreatedJob() {
+	ts.givenScheduleResource("* * * * *")
+
+	persistedSchedule := &k8upv1.Schedule{}
+	ts.FetchResource(k8upv1.MapToNamespacedName(ts.givenSchedule), persistedSchedule)
+	ts.Require().NotEmpty(persistedSchedule.UID, "schedule must have a server-assigned UID before we exercise the cron callback")
+
+	config := job.NewConfig(ts.Client, persistedSchedule, cfg.Config.GetGlobalRepository())
+	handler := NewScheduleHandler(config, persistedSchedule, ts.Logger)
+
+	handler.executeCronSchedule(ts.Ctx, &k8upv1.Backup{})
+
+	backups := &k8upv1.BackupList{}
+	ts.FetchResources(backups, client.InNamespace(ts.NS))
+	ts.Require().Len(backups.Items, 1, "exactly one Backup should be created by one cron tick")
+
+	ref := metav1.GetControllerOf(&backups.Items[0])
+	ts.Require().NotNilf(ref, "Backup must have a controller OwnerReference, got: %+v", backups.Items[0].OwnerReferences)
+	ts.Assert().Equal(persistedSchedule.UID, ref.UID, "controller ref UID must match the owning Schedule")
 }
 
 func (ts *ScheduleControllerTestSuite) whenReconciling(givenSchedule *k8upv1.Schedule) {


### PR DESCRIPTION
This adds a regression test and fixes #1212 

TLDR; Multiple Schedules creating jobs of the same kind in one namespace shared a single cleanup pool, so a busy Schedule could evict every recent job of a less busy one, hiding successful (or failed) backups from users.

Some more verbose notes (LLM-derived, so a bit wordy):

Scheduled jobs now get a controller reference (Controller=true) and history-limit cleanup only considers jobs sharing the same owner UID. Jobs created by earlier k8up versions carry the Schedule owner ref without the Controller flag; controllerUID falls back to it so they are still cleaned up after an upgrade. One-off jobs without any owner keep grouping together, as before.

Also dropped the redundant namespace parameter from CleanupOldResources: every caller passed the running job's own namespace, and since sibling matching via owner references is namespace-local anyway, any other  value would be a bug — so it's now derived from the job itself.