### PR TITLE
monitoring: add k8up_schedule_last_job_succeeded gauge

### DIFF
--- a/api/v1/common_types.go
+++ b/api/v1/common_types.go
@@ -76,6 +76,9 @@ const (
 	LabelK8upType = "k8up.io/type"
 	// LabelK8upOwnedBy is a label used to indicated which resource owns this resource to make it easy to fetch owned resources.
 	LabelK8upOwnedBy = "k8up.io/owned-by"
+	// LabelK8upScheduleName is the label key that records which Schedule created a job object.
+	// Set by the schedule controller; read by the monitoring package to populate per-schedule metrics.
+	LabelK8upScheduleName = "k8up.io/schedule-name"
 	// Deprecated: LegacyLabelK8upType is the former label key that identified the job type
 	LegacyLabelK8upType = "k8up.syn.tools/type"
 	// LabelManagedBy identifies the tool being used to manage the operation of a resource

--- a/operator/job/job.go
+++ b/operator/job/job.go
@@ -135,9 +135,15 @@ func UpdateStatus(ctx context.Context, batchJob *batchv1.Job, obj k8upv1.JobObje
 
 	if HasSucceeded(batchJob.Status.Conditions) {
 		SetSucceeded(ctx, batchJob.Name, batchJob.Namespace, obj.GetType(), &objStatus, message)
+		if scheduleName, ok := obj.GetLabels()[k8upv1.LabelK8upScheduleName]; ok {
+			monitoring.SetScheduleLastJobStatus(batchJob.Namespace, scheduleName, obj.GetType(), true)
+		}
 	}
 	if HasFailed(batchJob.Status.Conditions) {
 		SetFailed(ctx, batchJob.Name, batchJob.Namespace, obj.GetType(), &objStatus, message)
+		if scheduleName, ok := obj.GetLabels()[k8upv1.LabelK8upScheduleName]; ok {
+			monitoring.SetScheduleLastJobStatus(batchJob.Namespace, scheduleName, obj.GetType(), false)
+		}
 	}
 	if HasStarted(batchJob.Status.Conditions) {
 		objStatus.SetStarted(message)

--- a/operator/monitoring/prometheus.go
+++ b/operator/monitoring/prometheus.go
@@ -33,6 +33,11 @@ var (
 	}, []string{
 		"namespace",
 	})
+
+	scheduleLastJobSucceeded = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "k8up_schedule_last_job_succeeded",
+		Help: "1 if the most recent job triggered by this schedule succeeded, 0 if it failed.",
+	}, []string{"namespace", "schedule", "jobType"})
 )
 
 func IncFailureCounters(namespace string, jobType v1.JobType) {
@@ -53,6 +58,16 @@ func DecRegisteredSchedulesGauge(namespace string) {
 	scheduleGauge.WithLabelValues(namespace).Dec()
 }
 
+// SetScheduleLastJobStatus records whether the last job triggered by a schedule
+// succeeded (1) or failed (0). Call this after each scheduled job completes.
+func SetScheduleLastJobStatus(namespace, scheduleName string, jobType v1.JobType, succeeded bool) {
+	val := 0.0
+	if succeeded {
+		val = 1.0
+	}
+	scheduleLastJobSucceeded.WithLabelValues(namespace, scheduleName, jobType.String()).Set(val)
+}
+
 func init() {
 	// Register custom metrics with the global prometheus registry
 	metrics.Registry.MustRegister(
@@ -60,5 +75,6 @@ func init() {
 		metricsSuccessCounter,
 		metricsTotalCounter,
 		scheduleGauge,
+		scheduleLastJobSucceeded,
 	)
 }

--- a/operator/schedulecontroller/handler.go
+++ b/operator/schedulecontroller/handler.go
@@ -160,6 +160,14 @@ func (s *ScheduleHandler) executeCronSchedule(ctx context.Context, obj k8upv1.Jo
 		log.Error(err, "Could not set controller reference", "type", obj.GetType(), "namespace", obj.GetNamespace(), "name", obj.GetName())
 		return
 	}
+
+	labels := obj.GetLabels()
+	if labels == nil {
+		labels = make(map[string]string)
+	}
+	labels[k8upv1.LabelK8upScheduleName] = s.schedule.Name
+	obj.SetLabels(labels)
+
 	err := s.Client.Create(ctx, obj.DeepCopyObject().(client.Object))
 	if err != nil {
 		log.Error(err, "Could not create new object", "type", obj.GetType(), "namespace", obj.GetNamespace(), "name", obj.GetName())


### PR DESCRIPTION
﻿Closes #1200 — adds a `k8up_schedule_last_job_succeeded` Prometheus gauge so operators can alert when the last job for a schedule failed, without relying on cumulative counters.

## Metric

```
k8up_schedule_last_job_succeeded{namespace, schedule, jobType}
```
- **1** if the most recent job triggered by this schedule succeeded
- **0** if it failed

Example alert rule:
```yaml
- alert: K8upScheduleLastJobFailed
  expr: k8up_schedule_last_job_succeeded == 0
  for: 5m
  labels:
    severity: warning
  annotations:
    summary: "Last {{ .jobType }} job for schedule {{ .schedule }} failed"
```

## Implementation

| File | Change |
|------|--------|
| `api/v1/common_types.go` | Add `LabelK8upScheduleName = "k8up.io/schedule-name"` |
| `operator/schedulecontroller/handler.go` | Set the label on every job object created by `executeCronSchedule` |
| `operator/monitoring/prometheus.go` | Register gauge + expose `SetScheduleLastJobStatus()` |
| `operator/job/job.go` | Call `SetScheduleLastJobStatus()` from `UpdateStatus()` when finish is detected and the label is present |

The label is only set for schedule-triggered jobs, so manually created Backup/Restore/etc. objects do not affect the gauge.
