### PR TITLE
fix: pass imagePullSecrets to cleanup job in Helm chart

### DIFF
--- a/charts/k8up/templates/cleanup-hook.yaml
+++ b/charts/k8up/templates/cleanup-hook.yaml
@@ -82,6 +82,10 @@ spec:
     spec:
       restartPolicy: Never
       serviceAccountName: cleanup-service-account
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:


### PR DESCRIPTION
The cleanup hook job ignored imagePullSecrets from values.yaml, causing image pull failures when using private registries that require authentication.

Adds the same imagePullSecrets block already present in the deployment template (charts/k8up/templates/deployment.yaml) to the cleanup job pod spec (charts/k8up/templates/cleanup-hook.yaml).

Closes #1215