### PR TITLE
Preserve volumeMounts from PodConfig

### DIFF
--- a/e2e/definitions/backup/podconfig.yaml
+++ b/e2e/definitions/backup/podconfig.yaml
@@ -13,8 +13,15 @@ spec:
           command: # Should not be in the final container
             - more
             - foo
+          volumeMounts:
+            - mountPath: /.cache
+              name: cache
           env:
             - name: FOO
               value: bar
           securityContext:
             allowPrivilegeEscalation: true
+      volumes:
+        - name: cache
+          emptyDir:
+            sizeLimit: 100Mi

--- a/e2e/test-03-backup.bats
+++ b/e2e/test-03-backup.bats
@@ -59,4 +59,10 @@ DEBUG_DETIK="true"
 
 	secCont="$(kubectl -n "${DETIK_CLIENT_NAMESPACE}" get podConfig podconfig -ojson | jq -r '.spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation')"
 	verify_job_pod_values 'k8up.io/owned-by=backup_k8up-backup' .spec.containers[0].securityContext.allowPrivilegeEscalation "${secCont}"
+
+	secCont="$(kubectl -n "${DETIK_CLIENT_NAMESPACE}" get podConfig podconfig -ojson | jq -r '.spec.template.spec.containers[0].volumeMounts[0].mountPath')"
+	verify_job_pod_values 'k8up.io/owned-by=backup_k8up-backup' .spec.containers[0].volumeMounts[0].mountPath "${secCont}"
+
+	secCont="$(kubectl -n "${DETIK_CLIENT_NAMESPACE}" get podConfig podconfig -ojson | jq -r '.spec.template.spec.volumes[0].name')"
+	verify_job_pod_values 'k8up.io/owned-by=backup_k8up-backup' .spec.volumes[0].name "${secCont}"
 }

--- a/operator/archivecontroller/executor.go
+++ b/operator/archivecontroller/executor.go
@@ -55,8 +55,8 @@ func (a *ArchiveExecutor) Execute(ctx context.Context) error {
 
 		batchJob.Spec.Template.Spec.Containers[0].Env = append(batchJob.Spec.Template.Spec.Containers[0].Env, a.setupEnvVars(ctx, a.archive)...)
 		a.archive.Spec.AppendEnvFromToContainer(&batchJob.Spec.Template.Spec.Containers[0])
-		batchJob.Spec.Template.Spec.Containers[0].VolumeMounts = a.attachTLSVolumeMounts()
-		batchJob.Spec.Template.Spec.Volumes = utils.AttachEmptyDirVolumes(a.archive.Spec.Volumes)
+		batchJob.Spec.Template.Spec.Containers[0].VolumeMounts = append(batchJob.Spec.Template.Spec.Containers[0].VolumeMounts, a.attachTLSVolumeMounts()...)
+		batchJob.Spec.Template.Spec.Volumes = append(batchJob.Spec.Template.Spec.Volumes, utils.AttachEmptyDirVolumes(a.archive.Spec.Volumes)...)
 
 		batchJob.Spec.Template.Spec.Containers[0].Args = a.setupArgs()
 

--- a/operator/backupcontroller/executor.go
+++ b/operator/backupcontroller/executor.go
@@ -354,7 +354,8 @@ func (b *BackupExecutor) startBackup(ctx context.Context) error {
 			b.backup.Spec.AppendEnvFromToContainer(&batchJob.job.Spec.Template.Spec.Containers[0])
 			batchJob.job.Spec.Template.Spec.Volumes = append(batchJob.job.Spec.Template.Spec.Volumes, batchJob.volumes...)
 			batchJob.job.Spec.Template.Spec.Volumes = append(batchJob.job.Spec.Template.Spec.Volumes, utils.AttachEmptyDirVolumes(b.backup.Spec.Volumes)...)
-			batchJob.job.Spec.Template.Spec.Containers[0].VolumeMounts = append(b.newVolumeMounts(batchJob.volumes), b.attachTLSVolumeMounts()...)
+			batchJob.job.Spec.Template.Spec.Containers[0].VolumeMounts = append(batchJob.job.Spec.Template.Spec.Containers[0].VolumeMounts, b.newVolumeMounts(batchJob.volumes)...)
+			batchJob.job.Spec.Template.Spec.Containers[0].VolumeMounts = append(batchJob.job.Spec.Template.Spec.Containers[0].VolumeMounts, b.attachTLSVolumeMounts()...)
 			batchJob.job.Spec.BackoffLimit = ptr.To(int32(cfg.Config.GlobalBackoffLimit))
 
 			batchJob.job.Spec.Template.Spec.Containers[0].Args = b.setupArgs(batchJob.resticArgs)

--- a/operator/restorecontroller/executor.go
+++ b/operator/restorecontroller/executor.go
@@ -80,7 +80,8 @@ func (r *RestoreExecutor) createRestoreObject(ctx context.Context, restore *k8up
 		volumes, volumeMounts := r.volumeConfig(restore)
 		batchJob.Spec.Template.Spec.Volumes = append(batchJob.Spec.Template.Spec.Volumes, volumes...)
 		batchJob.Spec.Template.Spec.Volumes = append(batchJob.Spec.Template.Spec.Volumes, utils.AttachEmptyDirVolumes(r.restore.Spec.Volumes)...)
-		batchJob.Spec.Template.Spec.Containers[0].VolumeMounts = append(volumeMounts, r.attachTLSVolumeMounts()...)
+		batchJob.Spec.Template.Spec.Containers[0].VolumeMounts = append(batchJob.Spec.Template.Spec.Containers[0].VolumeMounts, volumeMounts...)
+		batchJob.Spec.Template.Spec.Containers[0].VolumeMounts = append(batchJob.Spec.Template.Spec.Containers[0].VolumeMounts, r.attachTLSVolumeMounts()...)
 
 		args, argsErr := r.setupArgs(restore)
 		batchJob.Spec.Template.Spec.Containers[0].Args = args


### PR DESCRIPTION
## Summary

Preserve volumeMounts from PodConfig.

This currently handled for Check and Prune, but not Backup, Archive, or Restore.

Issue mentioned here in a comment: https://github.com/k8up-io/k8up/issues/584#issuecomment-2247439489

Supersedes https://github.com/k8up-io/k8up/pull/1073, and fixes once instance in the ArchiveController missed by the original PR.
Thanks to @ahyattdev for the original code.

Our use-case: Mounting a CSI-backed secret storage volume.

## Checklist

### For Code changes

- [ ] Categorize the PR by setting a good title and adding one of the labels:
  `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
  as they show up in the changelog
- [ ] PR contains the label `area:operator`
- [x] Commits are [signed off](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
- [x] Link this PR to related issues
- [x] I have not made _any_ changes in the `charts/` directory.