### PR TITLE
allow annotations on PreBackupPod metadata

### DIFF
--- a/charts/k8up/crds/k8up.io_prebackuppods.yaml
+++ b/charts/k8up/crds/k8up.io_prebackuppods.yaml
@@ -56,6 +56,7 @@ spec:
                       Standard object's metadata.
                       More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
                     type: object
+                    x-kubernetes-preserve-unknown-fields: true
                   spec:
                     description: |-
                       Specification of the desired behavior of the pod.

--- a/config/crd/apiextensions.k8s.io/v1/k8up.io_prebackuppods.yaml
+++ b/config/crd/apiextensions.k8s.io/v1/k8up.io_prebackuppods.yaml
@@ -56,6 +56,7 @@ spec:
                       Standard object's metadata.
                       More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
                     type: object
+                    x-kubernetes-preserve-unknown-fields: true
                   spec:
                     description: |-
                       Specification of the desired behavior of the pod.


### PR DESCRIPTION
The PreBackupPod CRD schema rejected metadata.annotations with a strict decoding error because the metadata field was defined as type: object without x-kubernetes-preserve-unknown-fields. Adding it allows users to set annotations (e.g. Vault agent sidecar injection) on prebackup pods.