### PR TITLE
Fix potentially duplicate volumes and mounts

### DIFF
--- a/e2e/lib/k8up.bash
+++ b/e2e/lib/k8up.bash
@@ -236,15 +236,21 @@ given_a_rwo_pvc_subject_in_controlplane_node() {
 }
 
 given_s3_storage() {
-	# Speed this step up
-	(helm -n "${MINIO_NAMESPACE}" list | grep minio >/dev/null) && return
-	helm repo add minio https://charts.min.io/ --force-update
-	helm repo update
-	helm upgrade --install minio \
-		--values definitions/minio/helm.yaml \
-		--create-namespace \
-		--namespace "${MINIO_NAMESPACE}" \
-		minio/minio
+	# Speed this step up: only (re)install when the release is missing.
+	if ! (helm -n "${MINIO_NAMESPACE}" list | grep minio >/dev/null); then
+		helm repo add minio https://charts.min.io/ --force-update
+		helm repo update
+		helm upgrade --install minio \
+			--values definitions/minio/helm.yaml \
+			--create-namespace \
+			--namespace "${MINIO_NAMESPACE}" \
+			minio/minio
+	fi
+
+	# Wait for minio to actually serve, not just for the helm release to exist.
+	# The release can linger from a previous run while its pods are down, which
+	# otherwise surfaces later as "connection refused" in the restic verify pods.
+	kubectl -n "${MINIO_NAMESPACE}" rollout status deployment/minio --timeout=2m
 
 	echo "✅  S3 Storage is ready"
 }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/k8up-io/k8up/v2
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/firepear/qsplit/v2 v2.5.0

--- a/operator/archivecontroller/executor.go
+++ b/operator/archivecontroller/executor.go
@@ -55,8 +55,8 @@ func (a *ArchiveExecutor) Execute(ctx context.Context) error {
 
 		batchJob.Spec.Template.Spec.Containers[0].Env = append(batchJob.Spec.Template.Spec.Containers[0].Env, a.setupEnvVars(ctx, a.archive)...)
 		a.archive.Spec.AppendEnvFromToContainer(&batchJob.Spec.Template.Spec.Containers[0])
-		batchJob.Spec.Template.Spec.Containers[0].VolumeMounts = append(batchJob.Spec.Template.Spec.Containers[0].VolumeMounts, a.attachTLSVolumeMounts()...)
-		batchJob.Spec.Template.Spec.Volumes = append(batchJob.Spec.Template.Spec.Volumes, utils.AttachEmptyDirVolumes(a.archive.Spec.Volumes)...)
+		batchJob.Spec.Template.Spec.Containers[0].VolumeMounts = utils.AppendUniqueVolumeMounts(batchJob.Spec.Template.Spec.Containers[0].VolumeMounts, a.attachTLSVolumeMounts()...)
+		batchJob.Spec.Template.Spec.Volumes = utils.AppendUniqueVolumes(batchJob.Spec.Template.Spec.Volumes, utils.AttachEmptyDirVolumes(a.archive.Spec.Volumes)...)
 
 		batchJob.Spec.Template.Spec.Containers[0].Args = a.setupArgs()
 

--- a/operator/backupcontroller/executor.go
+++ b/operator/backupcontroller/executor.go
@@ -352,10 +352,10 @@ func (b *BackupExecutor) startBackup(ctx context.Context) error {
 				})
 			}
 			b.backup.Spec.AppendEnvFromToContainer(&batchJob.job.Spec.Template.Spec.Containers[0])
-			batchJob.job.Spec.Template.Spec.Volumes = append(batchJob.job.Spec.Template.Spec.Volumes, batchJob.volumes...)
-			batchJob.job.Spec.Template.Spec.Volumes = append(batchJob.job.Spec.Template.Spec.Volumes, utils.AttachEmptyDirVolumes(b.backup.Spec.Volumes)...)
-			batchJob.job.Spec.Template.Spec.Containers[0].VolumeMounts = append(batchJob.job.Spec.Template.Spec.Containers[0].VolumeMounts, b.newVolumeMounts(batchJob.volumes)...)
-			batchJob.job.Spec.Template.Spec.Containers[0].VolumeMounts = append(batchJob.job.Spec.Template.Spec.Containers[0].VolumeMounts, b.attachTLSVolumeMounts()...)
+			batchJob.job.Spec.Template.Spec.Volumes = utils.AppendUniqueVolumes(batchJob.job.Spec.Template.Spec.Volumes, batchJob.volumes...)
+			batchJob.job.Spec.Template.Spec.Volumes = utils.AppendUniqueVolumes(batchJob.job.Spec.Template.Spec.Volumes, utils.AttachEmptyDirVolumes(b.backup.Spec.Volumes)...)
+			batchJob.job.Spec.Template.Spec.Containers[0].VolumeMounts = utils.AppendUniqueVolumeMounts(batchJob.job.Spec.Template.Spec.Containers[0].VolumeMounts, b.newVolumeMounts(batchJob.volumes)...)
+			batchJob.job.Spec.Template.Spec.Containers[0].VolumeMounts = utils.AppendUniqueVolumeMounts(batchJob.job.Spec.Template.Spec.Containers[0].VolumeMounts, b.attachTLSVolumeMounts()...)
 			batchJob.job.Spec.BackoffLimit = ptr.To(int32(cfg.Config.GlobalBackoffLimit))
 
 			batchJob.job.Spec.Template.Spec.Containers[0].Args = b.setupArgs(batchJob.resticArgs)

--- a/operator/restorecontroller/executor.go
+++ b/operator/restorecontroller/executor.go
@@ -78,10 +78,10 @@ func (r *RestoreExecutor) createRestoreObject(ctx context.Context, restore *k8up
 		restore.Spec.AppendEnvFromToContainer(&batchJob.Spec.Template.Spec.Containers[0])
 
 		volumes, volumeMounts := r.volumeConfig(restore)
-		batchJob.Spec.Template.Spec.Volumes = append(batchJob.Spec.Template.Spec.Volumes, volumes...)
-		batchJob.Spec.Template.Spec.Volumes = append(batchJob.Spec.Template.Spec.Volumes, utils.AttachEmptyDirVolumes(r.restore.Spec.Volumes)...)
-		batchJob.Spec.Template.Spec.Containers[0].VolumeMounts = append(batchJob.Spec.Template.Spec.Containers[0].VolumeMounts, volumeMounts...)
-		batchJob.Spec.Template.Spec.Containers[0].VolumeMounts = append(batchJob.Spec.Template.Spec.Containers[0].VolumeMounts, r.attachTLSVolumeMounts()...)
+		batchJob.Spec.Template.Spec.Volumes = utils.AppendUniqueVolumes(batchJob.Spec.Template.Spec.Volumes, volumes...)
+		batchJob.Spec.Template.Spec.Volumes = utils.AppendUniqueVolumes(batchJob.Spec.Template.Spec.Volumes, utils.AttachEmptyDirVolumes(r.restore.Spec.Volumes)...)
+		batchJob.Spec.Template.Spec.Containers[0].VolumeMounts = utils.AppendUniqueVolumeMounts(batchJob.Spec.Template.Spec.Containers[0].VolumeMounts, volumeMounts...)
+		batchJob.Spec.Template.Spec.Containers[0].VolumeMounts = utils.AppendUniqueVolumeMounts(batchJob.Spec.Template.Spec.Containers[0].VolumeMounts, r.attachTLSVolumeMounts()...)
 
 		args, argsErr := r.setupArgs(restore)
 		batchJob.Spec.Template.Spec.Containers[0].Args = args

--- a/operator/utils/utils.go
+++ b/operator/utils/utils.go
@@ -18,6 +18,46 @@ const (
 	_resticCacheDirName = "restic-cache-dir"
 )
 
+// AppendUniqueVolumeMounts appends mounts to existing, skipping mounts whose
+// mountPath is already taken. Kubernetes requires mountPaths to be unique per
+// container. Existing mounts (e.g. from a PodConfig) win over appended defaults.
+func AppendUniqueVolumeMounts(existing []corev1.VolumeMount, mounts ...corev1.VolumeMount) []corev1.VolumeMount {
+	for _, mount := range mounts {
+		taken := false
+		for _, e := range existing {
+			if e.MountPath == mount.MountPath {
+				taken = true
+				break
+			}
+		}
+
+		if !taken {
+			existing = append(existing, mount)
+		}
+	}
+	return existing
+}
+
+// AppendUniqueVolumes appends volumes to existing, skipping volumes whose name
+// is already taken. Kubernetes requires volume names to be unique per pod.
+// Existing volumes (e.g. from a PodConfig) win over appended defaults.
+func AppendUniqueVolumes(existing []corev1.Volume, volumes ...corev1.Volume) []corev1.Volume {
+	for _, volume := range volumes {
+		taken := false
+		for _, e := range existing {
+			if e.Name == volume.Name {
+				taken = true
+				break
+			}
+		}
+
+		if !taken {
+			existing = append(existing, volume)
+		}
+	}
+	return existing
+}
+
 func RandomStringGenerator(n int) string {
 	characters := []rune("abcdefghijklmnopqrstuvwxyz1234567890")
 	rand.New(rand.NewSource(time.Now().UnixNano()))

--- a/operator/utils/utils_test.go
+++ b/operator/utils/utils_test.go
@@ -671,3 +671,33 @@ func Test_AttachTLSVolumeMounts(t *testing.T) {
 		})
 	}
 }
+
+func Test_AppendUniqueVolumeMounts(t *testing.T) {
+	existing := []corev1.VolumeMount{
+		{Name: "cache", MountPath: "/.cache"},
+	}
+	got := AppendUniqueVolumeMounts(existing,
+		corev1.VolumeMount{Name: "data", MountPath: "/data"},
+		corev1.VolumeMount{Name: "restic-cache-dir", MountPath: "/.cache"},
+	)
+	want := []corev1.VolumeMount{
+		{Name: "cache", MountPath: "/.cache"},
+		{Name: "data", MountPath: "/data"},
+	}
+	assert.Equal(t, want, got)
+}
+
+func Test_AppendUniqueVolumes(t *testing.T) {
+	existing := []corev1.Volume{
+		{Name: "cache", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
+	}
+	got := AppendUniqueVolumes(existing,
+		corev1.Volume{Name: "cache", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
+		corev1.Volume{Name: "data", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
+	)
+	want := []corev1.Volume{
+		{Name: "cache", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
+		{Name: "data", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
+	}
+	assert.Equal(t, want, got)
+}


### PR DESCRIPTION
## Summary

#1223 introduced a potential bug where duplicate volumes and volumeMounts can be defined.

This commit adds functions to deduplicate the volumes and volumeMounts.

The e2e tests caught this issue:
```
make e2e-test -e KIND_KUBECTL_ARGS=--validate=false -e bats_args="--report-formatter junit" -e BATS_FILES="test-03-backup.bats"
```

For some reason I did not notice the broken check on the PR.

CC: @beniwtv 

## Checklist

### For Code changes

- [x] Categorize the PR by setting a good title and adding one of the labels:
  `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
  as they show up in the changelog
- [x] PR contains the label `area:operator`
- [x] Commits are [signed off](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
- [x] Link this PR to related issues
- [x] I have not made _any_ changes in the `charts/` directory.

<!--
NOTE:
Do *not* mix code changes with chart changes, it will break the release process.
Delete the checklist section that doesn't apply to the change.

NOTE:
CI-only changes (GitHub Actions workflows, linter configs, etc.) do not need
an area label — the area labels are for code and chart changes only.

NOTE:
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
