### PR TITLE
fix(scheduler): randomize @annually-random schedules

### DIFF
--- a/operator/schedulecontroller/randomizer.go
+++ b/operator/schedulecontroller/randomizer.go
@@ -40,8 +40,7 @@ func randomizeSchedule(seed string, originalSchedule k8upv1.ScheduleDefinition) 
 		return k8upv1.ScheduleDefinition(fmt.Sprintf("%d %d * * *", minute, hour)), nil
 	case ScheduleMonthlyRandom:
 		return k8upv1.ScheduleDefinition(fmt.Sprintf("%d %d %d * *", minute, hour, dayOfMonth)), nil
-	case ScheduleAnnuallyRandom:
-	case ScheduleYearlyRandom:
+	case ScheduleAnnuallyRandom, ScheduleYearlyRandom:
 		month := remainderFromModulo(checksum, 12, 1)
 		return k8upv1.ScheduleDefinition(fmt.Sprintf("%d %d %d %d *", minute, hour, dayOfMonth, month)), nil
 	case ScheduleWeeklyRandom:
@@ -50,7 +49,6 @@ func randomizeSchedule(seed string, originalSchedule k8upv1.ScheduleDefinition) 
 	default:
 		return originalSchedule, fmt.Errorf("unrecognized random schedule: '%s'", originalSchedule)
 	}
-	return originalSchedule, nil
 }
 
 // calculateChecksumFromSeed calculates a SHA1 hexadecimal checksum from the given seed.

--- a/operator/schedulecontroller/randomizer_test.go
+++ b/operator/schedulecontroller/randomizer_test.go
@@ -72,6 +72,11 @@ func Test_randomizeSchedule_VerifySchedules(t *testing.T) {
 			schedule:         "@yearly-random",
 			expectedSchedule: "52 4 26 5 *",
 		},
+		"WhenScheduleRandomAnnuallyGiven_ThenReturnStableRandomizedSchedule": {
+			// @annually-random is documented as an alias of @yearly-random.
+			schedule:         "@annually-random",
+			expectedSchedule: "52 4 26 5 *",
+		},
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {


### PR DESCRIPTION
### Summary

`@annually-random` schedules are silently never run. The docs list it as an alias of `@yearly-random`, but it is returned unrandomized and then rejected by the cron parser, so the backup never fires.

### Root cause

In `operator/schedulecontroller/randomizer.go` the switch had:

```go
case ScheduleAnnuallyRandom:
case ScheduleYearlyRandom:
    month := remainderFromModulo(checksum, 12, 1)
    return k8upv1.ScheduleDefinition(fmt.Sprintf("%d %d %d %d *", ...)), nil
```

Go `switch` cases don't fall through, so `@annually-random` matched the **empty** `case ScheduleAnnuallyRandom:` and dropped through to the function's final `return originalSchedule, nil` — returning the literal `"@annually-random"` with no error. That string is handed to `robfig/cron`'s `AddFunc` (`operator/scheduler/scheduler.go`), which doesn't recognise `@annually-random`, so the schedule is never registered and the yearly backup silently never runs. `@yearly-random` works, which makes it easy to miss.

### Fix

Combine the cases so `@annually-random` is randomized identically to `@yearly-random`:

```go
case ScheduleAnnuallyRandom, ScheduleYearlyRandom:
```

Added a regression test (`WhenScheduleRandomAnnuallyGiven_...`) asserting `@annually-random` produces the same stable randomized schedule as `@yearly-random`. It fails before the change (returns `@annually-random` verbatim) and passes after. `go build ./...`, the randomizer unit tests, and `gofmt` are clean.

---
*Disclosure: I used an LLM to help find and draft this fix; I reproduced the bug, wrote the test, and verified everything myself.*
