### PR TITLE
[enhancement] Add schedule times to kubectl get schedules

### DIFF
--- a/config/crd/apiextensions.k8s.io/v1/k8up.io_schedules.yaml
+++ b/config/crd/apiextensions.k8s.io/v1/k8up.io_schedules.yaml
@@ -14,7 +14,27 @@ spec:
     singular: schedule
   scope: Namespaced
   versions:
-  - name: v1
+  - additionalPrinterColumns:
+    - description: Schedule of the Backup job
+      jsonPath: .spec.backup.schedule
+      name: Backup Schedule
+      type: string
+    - description: Schedule of the Check job
+      jsonPath: .spec.check.schedule
+      name: Check Schedule
+      type: string
+    - description: Schedule of the Prune job
+      jsonPath: .spec.prune.schedule
+      name: Prune Schedule
+      type: string
+    - description: Schedule of the Archive job
+      jsonPath: .spec.archive.schedule
+      name: Archive Schedule
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
     schema:
       openAPIV3Schema:
         description: Schedule is the Schema for the schedules API


### PR DESCRIPTION
## Summary

* Extend the schedule listing with additionalPrinterColumns containing all sub-schedules

```
NAMESPACE     NAME       BACKUP SCHEDULE    CHECK SCHEDULE   PRUNE SCHEDULE   ARCHIVE SCHEDULE   AGE
paperless     archive    5 0 * * *          10 4 * * *                                           2d18h
```

## Checklist

### For Helm Chart changes

- [x] Categorize the PR by setting a good title and adding one of the labels:
  `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
  as they show up in the changelog
- [ ] PR contains the label `area:chart`
- [ ] PR contains the chart label, e.g. `chart:k8up`
- [x] Commits are [signed off](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
- [x] ~~Variables are documented in the values.yaml using the format required by [Helm-Docs](https://github.com/norwoodj/helm-docs#valuesyaml-metadata).~~ not needed
- [x] ~~Chart Version bumped if immediate release after merging is planned~~ not needed
- [x] I have run `make chart-docs`
- [x] ~~Link this PR to related code release or other issues.~~ no references known

<!--
NOTE:
Do *not* mix code changes with chart changes, it will break the release process.
Delete the checklist section that doesn't apply to the change.

NOTE:
CI-only changes (GitHub Actions workflows, linter configs, etc.) do not need
an area label — the area labels are for code and chart changes only.

NOTE:
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
