### PR TITLE
Set github action digests

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -14,23 +14,40 @@
   "packageRules": [
     {
       "description": "Label chart dependency updates",
-      "matchFileNames": ["charts/**"],
-      "addLabels": ["area:chart", "chart:k8up"]
+      "matchFileNames": [
+        "charts/**"
+      ],
+      "addLabels": [
+        "area:chart",
+        "chart:k8up"
+      ]
     },
     {
       "description": "Label operator dependency updates",
-      "matchFileNames": ["go.mod", "go.sum"],
-      "addLabels": ["area:operator"]
+      "matchFileNames": [
+        "go.mod",
+        "go.sum"
+      ],
+      "addLabels": [
+        "area:operator"
+      ]
     },
     {
       "description": "Automerge GitHub Actions (CI-only, no impact on shipped code)",
-      "matchManagers": ["github-actions"],
+      "matchManagers": [
+        "github-actions"
+      ],
       "automerge": true
     },
     {
       "description": "Automerge Docker base image patch/minor updates",
-      "matchDatasources": ["docker"],
-      "matchUpdateTypes": ["patch", "minor"],
+      "matchDatasources": [
+        "docker"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
       "automerge": true
     },
     {

--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,8 @@
   "extends": [
     "config:base",
     ":gitSignOff",
-    ":disableDependencyDashboard"
+    ":disableDependencyDashboard",
+    "helpers:pinGitHubActionDigests"
   ],
   "labels": [
     "dependency"

--- a/renovate.json
+++ b/renovate.json
@@ -85,6 +85,15 @@
       "schedule": [
         "on the first day of the month"
       ]
+    },
+    {
+      "matchManagers": [
+        "github-actions"
+      ],
+      "groupName": "github actions dependencies",
+      "minimumReleaseAge": "7 days",
+      "prCreation": "not-pending",
+      "internalChecksFilter": "strict"
     }
   ],
   "prBodyNotes": [


### PR DESCRIPTION


## Summary

This commit will make renovate use digests for github actions instead of version numbers.

This slightly increases the security, since github actions don't provide locks for their versions. So a malicious actor could simply switch out a known good version of an action with a compromised one and github would gladly run it.

## Checklist

### For Code changes

- [x] Categorize the PR by setting a good title and adding one of the labels:
  `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
  as they show up in the changelog
- [x] PR contains the label `area:operator`
- [x] Commits are [signed off](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
- [x] Link this PR to related issues
- [ ] I have not made _any_ changes in the `charts/` directory.


<!--
NOTE:
Do *not* mix code changes with chart changes, it will break the release process.
Delete the checklist section that doesn't apply to the change.

NOTE:
CI-only changes (GitHub Actions workflows, linter configs, etc.) do not need
an area label — the area labels are for code and chart changes only.

NOTE:
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
